### PR TITLE
Add User Badges

### DIFF
--- a/functions/studio-api/src/data/init.ts
+++ b/functions/studio-api/src/data/init.ts
@@ -1,12 +1,23 @@
 import { Sequelize } from 'sequelize/types';
 import Session from './models/Session';
 import User from './models/User';
+import Badge from './models/Badge';
+import UserBadge from './models/UserBadges';
 
 export const modelInitialization: (
   sequelize: Sequelize
 ) => Promise<void> = async (sequelize: Sequelize) => {
   User.register(sequelize);
   Session.register(sequelize);
+  Badge.register(sequelize);
+  UserBadge.register(sequelize);
 
-  // User.hasMany(Post, { foreignKey: 'creator_id' });
+  Badge.belongsToMany(User, {
+    through: UserBadge,
+    foreignKey: 'badge_id'
+  });
+  User.belongsToMany(Badge, {
+    through: UserBadge,
+    foreignKey: 'user_id'
+  });
 };

--- a/functions/studio-api/src/data/migrations/20220908075756-AddUserBadges.ts
+++ b/functions/studio-api/src/data/migrations/20220908075756-AddUserBadges.ts
@@ -1,0 +1,179 @@
+import { IMigrationDefinition } from 'db-facade';
+import { QueryInterface, DataTypes, Transaction, QueryTypes } from 'sequelize';
+
+enum CurrentBadgeTypes {
+  Achievement = 'achievement',
+  Administrative = 'administrative'
+}
+
+const today = new Date();
+const adminBadge = {
+  rarity: 5,
+  name: 'admin',
+  friendlyName: 'Administrator',
+  type: CurrentBadgeTypes.Administrative,
+  description: 'Allows accessing administrative features.',
+  created: today.toISOString()
+};
+
+export default {
+  name: '20220908075756-AddUserBadges',
+
+  up: (queryInterface: QueryInterface): Promise<void> => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction) => {
+        // ADD BADGES TABLE
+        await queryInterface.createTable(
+          'badges',
+          {
+            id: {
+              primaryKey: true,
+              type: DataTypes.INTEGER,
+              autoIncrement: true
+            },
+            type: {
+              type: DataTypes.ENUM,
+              values: [
+                CurrentBadgeTypes.Administrative,
+                CurrentBadgeTypes.Achievement
+              ]
+            },
+            rarity: {
+              type: DataTypes.SMALLINT,
+              allowNull: false,
+              defaultValue: 1
+            },
+            name: {
+              allowNull: false,
+              type: DataTypes.STRING,
+              unique: true
+            },
+            description: {
+              allowNull: false,
+              type: DataTypes.STRING
+            },
+            friendlyName: {
+              type: DataTypes.STRING,
+              field: 'friendly_name'
+            },
+            isPublic: {
+              type: DataTypes.BOOLEAN,
+              field: 'is_public',
+              defaultValue: false
+            },
+            created: {
+              type: DataTypes.DATE,
+              field: 'created'
+            },
+            updated: {
+              type: DataTypes.DATE,
+              field: 'updated'
+            }
+          },
+          { transaction }
+        );
+
+        // ADD USER_BADGES TABLE
+        await queryInterface.createTable(
+          'user_badges',
+          {
+            user_id: {
+              allowNull: false,
+              type: DataTypes.INTEGER,
+              primaryKey: true,
+              references: {
+                model: 'users',
+                key: 'id'
+              },
+              field: 'user_id'
+            },
+            badge_id: {
+              allowNull: false,
+              primaryKey: true,
+              type: DataTypes.INTEGER,
+              references: {
+                model: 'badges',
+                key: 'id'
+              },
+              field: 'badge_id'
+            },
+            unread: {
+              type: DataTypes.BOOLEAN,
+              defaultValue: true
+            },
+            created: {
+              type: DataTypes.DATE,
+              field: 'created'
+            },
+            updated: {
+              type: DataTypes.DATE,
+              field: 'updated'
+            }
+          },
+          { transaction }
+        );
+
+        // ADD ADMIN BADGE
+        await queryInterface.sequelize.query(
+          `
+          INSERT INTO badges (name, friendly_name, type, rarity, description, created, updated) VALUES
+          (
+            '${adminBadge.name}',
+            '${adminBadge.friendlyName}',
+            '${adminBadge.type}',
+            ${adminBadge.rarity},
+            '${adminBadge.description}',
+            '${adminBadge.created}',
+            '${adminBadge.created}' )
+        `,
+          { transaction }
+        );
+
+        // GRANT ADMIN BADGES
+        const initialAdmins = process.env.OS_ADMIN_USERS;
+        if (initialAdmins) {
+          const admins: Array<{ id: number }> =
+            await await queryInterface.sequelize.query(
+              `SELECT id from users WHERE source_id IN (${initialAdmins})`,
+              {
+                transaction,
+                type: QueryTypes.SELECT
+              }
+            );
+
+          const badges: Array<{ id: number }> =
+            await await queryInterface.sequelize.query(
+              `SELECT b.id from badges b WHERE b.name = 'admin' LIMIT 1`,
+              {
+                transaction,
+                type: QueryTypes.SELECT
+              }
+            );
+
+          for (const admin of admins) {
+            await queryInterface.sequelize.query(
+              `
+              INSERT INTO user_badges (user_id, badge_id, created, updated) VALUES
+              (
+                '${admin.id}',
+                '${badges[0].id}',
+                '${adminBadge.created}',
+                '${adminBadge.created}' )
+            `,
+              { transaction }
+            );
+          }
+        }
+      }
+    );
+  },
+
+  down: (queryInterface: QueryInterface): Promise<void> => {
+    return queryInterface.sequelize.transaction(
+      async (transaction: Transaction) => {
+        queryInterface.dropTable('user_badges', { transaction });
+        queryInterface.dropTable('badges', { transaction });
+      }
+    );
+  }
+} as IMigrationDefinition;

--- a/functions/studio-api/src/data/migrations/index.ts
+++ b/functions/studio-api/src/data/migrations/index.ts
@@ -14,6 +14,7 @@ export const getMigrationFiles = async (): Promise<IMigrationDefinition[]> => {
   // add migrations
   await addMigration(import('./20220620191016-AddUserTable'));
   await addMigration(import('./20220708155325-AddingSessionTable'));
+  await addMigration(import('./20220908075756-AddUserBadges'));
 
   return migrations;
 };

--- a/functions/studio-api/src/data/models/Badge.ts
+++ b/functions/studio-api/src/data/models/Badge.ts
@@ -1,0 +1,135 @@
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+import UserBadge from './UserBadges';
+
+interface BadgeAttributes {
+  id: number;
+  rarity: number; // 1 to 5, 5 is rarest, 1 is common
+  name: string; // unique identifier used to check against in the code
+  friendlyName: string;
+  type: BadgeTypes;
+  description: string;
+  isPublic: boolean; // show to user when not unlocked yet
+  created: Date;
+  updated: Date; // for tracking when the last user_badge was unlocked
+  UserBadge?: UserBadge;
+}
+
+// don't return these values in responses
+const PROTECTED_ATTRIBUTES: Array<keyof BadgeAttributes> = [];
+
+export interface BadgeOutput extends Omit<BadgeAttributes, 'UserBadge'> {
+  // merged user_badge attributes if they exist
+  obtained?: Date;
+  unread?: boolean;
+  userId?: number;
+}
+
+export interface BadgeInput
+  extends Optional<
+    BadgeAttributes,
+    'id' | 'rarity' | 'created' | 'updated' | 'isPublic' | 'UserBadge'
+  > {}
+
+export enum BadgeTypes {
+  Achievement = 'achievement',
+  Administrative = 'administrative'
+}
+
+export enum BadgeNames {
+  Admin = 'admin'
+}
+
+export class Badge
+  extends Model<BadgeAttributes, BadgeInput>
+  implements BadgeAttributes
+{
+  declare readonly id: number;
+  declare type: BadgeTypes;
+  declare rarity: number;
+  declare name: string;
+  declare friendlyName: string;
+  declare description: string;
+  declare isPublic: boolean;
+  declare updated: Date;
+  declare readonly created: Date;
+  declare readonly UserBadge?: UserBadge;
+
+  public async newActivity(): Promise<void> {
+    this.updated = new Date();
+    await this.save();
+  }
+
+  public toJSON(): BadgeOutput {
+    // hide protected fields
+    const json: BadgeAttributes = Object.assign({}, this.get());
+    for (const attr of PROTECTED_ATTRIBUTES) {
+      delete json[attr];
+    }
+    const output: BadgeOutput = json;
+    // flatten the user badge data if exists
+    if (json.UserBadge) {
+      const userBadge = json.UserBadge;
+      delete json['UserBadge'];
+      output.userId = userBadge.user_id;
+      output.obtained = userBadge.created;
+      output.unread = userBadge.unread;
+    }
+    return output;
+  }
+
+  public static register(sequelize: Sequelize) {
+    Badge.init(
+      {
+        id: {
+          primaryKey: true,
+          type: DataTypes.INTEGER,
+          autoIncrement: true
+        },
+        type: {
+          type: DataTypes.ENUM,
+          values: [BadgeTypes.Administrative, BadgeTypes.Achievement]
+        },
+        rarity: {
+          type: DataTypes.SMALLINT,
+          allowNull: false,
+          defaultValue: 1
+        },
+        name: {
+          allowNull: false,
+          type: DataTypes.STRING,
+          unique: true
+        },
+        description: {
+          allowNull: false,
+          type: DataTypes.STRING
+        },
+        friendlyName: {
+          type: DataTypes.STRING,
+          field: 'friendly_name'
+        },
+        isPublic: {
+          type: DataTypes.BOOLEAN,
+          field: 'is_public',
+          defaultValue: false
+        },
+        created: {
+          type: DataTypes.DATE,
+          field: 'created'
+        },
+        updated: {
+          type: DataTypes.DATE,
+          field: 'updated'
+        }
+      },
+      {
+        sequelize,
+        tableName: 'badges',
+        timestamps: true,
+        createdAt: 'created',
+        updatedAt: 'updated'
+      }
+    );
+  }
+}
+
+export default Badge;

--- a/functions/studio-api/src/data/models/User.ts
+++ b/functions/studio-api/src/data/models/User.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
 import { EncryptUtil } from '../../utilities/EncryptUtil';
+import Badge, { BadgeOutput } from './Badge';
 
 export interface UserAttributes {
   id: number;
@@ -11,6 +12,7 @@ export interface UserAttributes {
   sourceId?: string;
   authToken?: string;
   refreshToken?: string;
+  Badges?: Badge[];
 }
 
 // token encryption key
@@ -31,7 +33,9 @@ export interface UserInput
   > {}
 
 export interface UserOutput
-  extends Omit<UserAttributes, 'authToken' | 'refreshToken' | 'sourceId'> {}
+  extends Omit<UserAttributes, 'authToken' | 'refreshToken' | 'sourceId'> {
+  badges?: BadgeOutput[];
+}
 
 export class User
   extends Model<UserAttributes, UserInput>
@@ -48,6 +52,8 @@ export class User
   declare authToken?: string;
 
   // declare Sessions?: Session[];
+  declare Badges?: Badge[];
+  declare getBadges: () => Badge[];
 
   private _authToken?: string;
   private _refreshToken?: string;
@@ -92,7 +98,14 @@ export class User
     for (const attr of PROTECTED_ATTRIBUTES) {
       delete userJson[attr];
     }
-    return userJson;
+
+    // clean up badges
+    const output: UserOutput = userJson;
+    if (userJson.Badges && userJson.Badges.length > 0) {
+      output.badges = userJson.Badges.map((b) => b.toJSON());
+      delete output['Badges'];
+    }
+    return output;
   }
 
   // timestamps!

--- a/functions/studio-api/src/data/models/UserBadges.ts
+++ b/functions/studio-api/src/data/models/UserBadges.ts
@@ -1,0 +1,62 @@
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+
+interface UserBadgeAttributes {
+  unread: boolean;
+  created: Date;
+  updated: Date;
+  user_id: number;
+  badge_id: number;
+}
+
+// don't return these values in responses. The updated field is required so
+// we can utilize the timestamps feature, but doesn't make sense on this model
+// so we'll just exlude it from the toJSON output
+const PROTECTED_ATTRIBUTES: Array<keyof UserBadgeAttributes> = ['updated'];
+
+export interface UserBadgeOutput extends UserBadgeAttributes {}
+export interface UserBadgeInput
+  extends Optional<UserBadgeAttributes, 'unread' | 'created' | 'updated'> {}
+
+export class UserBadge
+  extends Model<UserBadgeAttributes, UserBadgeInput>
+  implements UserBadgeAttributes
+{
+  declare readonly created: Date;
+  declare readonly updated: Date;
+  declare readonly user_id: number;
+  declare readonly badge_id: number;
+  declare unread: boolean;
+
+  public toJSON(): UserBadgeOutput {
+    // hide protected fields
+    const json: UserBadgeAttributes = Object.assign({}, this.get());
+    for (const attr of PROTECTED_ATTRIBUTES) {
+      delete json[attr];
+    }
+    return json;
+  }
+
+  public static register(sequelize: Sequelize) {
+    UserBadge.init(
+      {
+        unread: {
+          type: DataTypes.BOOLEAN,
+          defaultValue: true
+        },
+        created: { type: DataTypes.DATE },
+        updated: { type: DataTypes.DATE },
+        user_id: { type: DataTypes.INTEGER },
+        badge_id: { type: DataTypes.INTEGER }
+      },
+      {
+        sequelize,
+        tableName: 'user_badges',
+        timestamps: true,
+        createdAt: 'created',
+        updatedAt: 'updated'
+      }
+    );
+  }
+}
+
+export default UserBadge;

--- a/functions/studio-api/src/routes/BadgeEndpoint.ts
+++ b/functions/studio-api/src/routes/BadgeEndpoint.ts
@@ -14,10 +14,10 @@ export class BadgeEndpoint extends BaseEndpoint implements RouterClass {
   constructor(
     @inject('RouteHarness') harness: HarnessDependency,
     @inject(LoggerFactory) loggerFactory: LoggerFactory,
-    @inject(BadgeService) BadgeService: BadgeService
+    @inject(BadgeService) badgeService: BadgeService
   ) {
     super(harness, loggerFactory);
-    this.badgeService = BadgeService;
+    this.badgeService = badgeService;
   }
 
   public mountRoutes() {

--- a/functions/studio-api/src/routes/BadgeEndpoint.ts
+++ b/functions/studio-api/src/routes/BadgeEndpoint.ts
@@ -3,28 +3,28 @@ import { HarnessDependency } from 'route-harness';
 import { inject, injectable } from 'tsyringe';
 import { AuthRequest } from '../services/Auth';
 import LoggerFactory from '../services/Logger';
-import { UserService } from '../services/UserService';
+import { BadgeService } from '../services/BadgeService';
 import ErrorResponse from '../utilities/ErrorResponse';
 import BaseEndpoint, { RouterClass } from './BaseEndpoint';
 
 @injectable()
-export class UserProfileEndpoint extends BaseEndpoint implements RouterClass {
-  private userService: UserService;
+export class BadgeEndpoint extends BaseEndpoint implements RouterClass {
+  private badgeService: BadgeService;
 
   constructor(
     @inject('RouteHarness') harness: HarnessDependency,
     @inject(LoggerFactory) loggerFactory: LoggerFactory,
-    @inject(UserService) userService: UserService
+    @inject(BadgeService) BadgeService: BadgeService
   ) {
     super(harness, loggerFactory);
-    this.userService = userService;
+    this.badgeService = BadgeService;
   }
 
   public mountRoutes() {
-    this.router.get('/', this.getUserProfile.bind(this));
+    this.router.get('/', this.getBadges.bind(this));
   }
 
-  async getUserProfile(req: AuthRequest) {
+  async getBadges(req: AuthRequest) {
     if (!req.user) {
       throw new ErrorResponse(
         StatusCodes.UNAUTHORIZED,
@@ -32,17 +32,20 @@ export class UserProfileEndpoint extends BaseEndpoint implements RouterClass {
       );
     }
 
-    // fetch user from db with all their associated data
-    const profile = await this.userService.getUserProfile(req.user?.id);
+    try {
+      // fetch user from db
+      const badges = await this.badgeService.getUserBadges(req.user.id);
 
-    if (!profile) {
-      throw new ErrorResponse(
-        StatusCodes.NOT_FOUND,
-        'Unable to find user with id: ' + req.user?.id
-      );
+      if (!badges || !badges.length) {
+        return [];
+      }
+
+      return badges.map((b) => b.toJSON());
+    } catch (err) {
+      this.logger.error(err);
+      return [];
     }
-    return profile.toJSON();
   }
 }
 
-export default UserProfileEndpoint;
+export default BadgeEndpoint;

--- a/functions/studio-api/src/routes/VersionEndpoint.ts
+++ b/functions/studio-api/src/routes/VersionEndpoint.ts
@@ -7,6 +7,8 @@ import { BaseEndpoint, RouterClass } from './BaseEndpoint';
 interface VersionResponse {
   app: string;
   db?: string;
+  runtime?: string;
+  typescript?: string;
 }
 
 @injectable()
@@ -30,19 +32,31 @@ export class VersionEndpoint extends BaseEndpoint implements RouterClass {
       `returning version ${packageJson.version} for endpoint response`
     );
     let dbVersion: string | undefined;
+    let tsVersion: string | undefined;
+    let runtimeVersion: string | undefined;
+
     try {
       if (req.user) {
+        tsVersion = packageJson.devDependencies['typescript'];
+        runtimeVersion = process.env['AWS_LAMBDA_JS_RUNTIME'];
         const db = container.resolve(DbLayer);
         dbVersion = await db.getDbVersion();
       }
     } catch (_) {
       this.logger.error('Unable to get version from database');
     }
+
     const resp: VersionResponse = {
       app: packageJson.version
     };
     if (dbVersion) {
       resp.db = dbVersion;
+    }
+    if (tsVersion) {
+      resp.typescript = tsVersion;
+    }
+    if (runtimeVersion) {
+      resp.runtime = runtimeVersion;
     }
     return resp;
   }

--- a/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
@@ -1,0 +1,60 @@
+import { StatusCodes } from 'http-status-codes';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import { AdminRequest } from '../../services/Auth';
+import LoggerFactory from '../../services/Logger';
+import { BadgeService } from '../../services/BadgeService';
+import ErrorResponse from '../../utilities/ErrorResponse';
+import { RouterClass } from './../BaseEndpoint';
+import AdminEndpoint, { isAdminRequest } from './AdminEndpoint';
+
+@injectable()
+export class AdminBadgesEndpoint extends AdminEndpoint implements RouterClass {
+  private badgeService: BadgeService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(BadgeService) BadgeService: BadgeService
+  ) {
+    super(harness, loggerFactory);
+    this.badgeService = BadgeService;
+  }
+
+  public mountRoutes() {
+    this.router.get('/:type', this.getBadgeByType.bind(this));
+    this.router.get('/', this.getBadges.bind(this));
+  }
+
+  async getBadges(req: AdminRequest) {
+    try {
+      this.logger.info('fetching all badges');
+      return await this.badgeService.getBadges();
+    } catch (err) {
+      this.logger.error(err);
+      return [];
+    }
+  }
+
+  async getBadgeByType(req: AdminRequest) {
+    try {
+      if (!isAdminRequest(req)) {
+        throw new ErrorResponse(StatusCodes.UNAUTHORIZED, 'Unauthorized');
+      }
+      this.logger.info('searching for badge by type: ' + req.params.type);
+      const result = await this.badgeService.getBadge(req.params.type);
+      if (!result) {
+        throw new ErrorResponse(
+          StatusCodes.NOT_FOUND,
+          'Unable to find badge with type ' + req.params.type
+        );
+      }
+      return result;
+    } catch (err) {
+      this.logger.error(err);
+      return [];
+    }
+  }
+}
+
+export default AdminBadgesEndpoint;

--- a/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
@@ -15,10 +15,10 @@ export class AdminBadgesEndpoint extends AdminEndpoint implements RouterClass {
   constructor(
     @inject('RouteHarness') harness: HarnessDependency,
     @inject(LoggerFactory) loggerFactory: LoggerFactory,
-    @inject(BadgeService) BadgeService: BadgeService
+    @inject(BadgeService) badgeService: BadgeService
   ) {
     super(harness, loggerFactory);
-    this.badgeService = BadgeService;
+    this.badgeService = badgeService;
   }
 
   public mountRoutes() {

--- a/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
@@ -26,7 +26,7 @@ export class AdminBadgesEndpoint extends AdminEndpoint implements RouterClass {
     this.router.get('/', this.getBadges.bind(this));
   }
 
-  async getBadges(req: AdminRequest) {
+  async getBadges() {
     try {
       this.logger.info('fetching all badges');
       return await this.badgeService.getBadges();

--- a/functions/studio-api/src/routes/admin/AdminEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminEndpoint.ts
@@ -1,0 +1,73 @@
+import { NextFunction, Response } from 'express';
+import { HarnessDependency, WrappedHandler } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import { BadgeNames } from '../../data/models/Badge';
+import { AdminRequest, AuthRequest } from '../../services/Auth';
+import LoggerFactory, { Logger } from '../../services/Logger';
+
+export interface AdminRouter {
+  get: (path: string, fn: AdminHandler) => void;
+  post: (path: string, fn: AdminHandler) => void;
+  put: (path: string, fn: AdminHandler) => void;
+  delete: (path: string, fn: AdminHandler) => void;
+  patch: (path: string, fn: AdminHandler) => void;
+}
+
+type AdminHandler = (
+  req: AdminRequest,
+  res: Response,
+  next?: NextFunction
+) => any;
+
+export const isAdminRequest = (
+  req: AuthRequest | AdminRequest
+): req is AdminRequest => {
+  return (
+    !!req.user &&
+    !!req.session &&
+    !!(req.user.Badges || []).find((badge) => badge.name === BadgeNames.Admin)
+  );
+};
+
+@injectable()
+export class AdminEndpoint {
+  public logger: Logger;
+  public router: AdminRouter;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory
+  ) {
+    this.logger = loggerFactory.getLogger(
+      `app:admin-route:${this.constructor.name}`
+    );
+    const router = harness.getRouterForClass(this.constructor.name);
+    this.router = {
+      get: (path: string, fn: AdminHandler) => {
+        router.get(path, fn as unknown as WrappedHandler);
+      },
+      post: (path: string, fn: AdminHandler) => {
+        router.post(path, fn as unknown as WrappedHandler);
+      },
+      put: (path: string, fn: AdminHandler) => {
+        router.put(path, fn as unknown as WrappedHandler);
+      },
+      delete: (path: string, fn: AdminHandler) => {
+        router.delete(path, fn as unknown as WrappedHandler);
+      },
+      patch: (path: string, fn: AdminHandler) => {
+        router.patch(path, fn as unknown as WrappedHandler);
+      }
+    };
+
+    this.mountRoutes();
+  }
+
+  mountRoutes(): void {
+    throw new Error(
+      `mountRoutes not implemented in route subclass ${this.constructor.name}`
+    );
+  }
+}
+
+export default AdminEndpoint;

--- a/functions/studio-api/src/routes/admin/AdminEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminEndpoint.ts
@@ -13,11 +13,11 @@ export interface AdminRouter {
   patch: (path: string, fn: AdminHandler) => void;
 }
 
-type AdminHandler = (
+type AdminHandler<T = unknown> = (
   req: AdminRequest,
   res: Response,
   next?: NextFunction
-) => any;
+) => T;
 
 export const isAdminRequest = (
   req: AuthRequest | AdminRequest

--- a/functions/studio-api/src/routes/index.ts
+++ b/functions/studio-api/src/routes/index.ts
@@ -34,8 +34,8 @@ export class ApiRoutes {
 
     const admin: () => RequestHandler = () => auth(true, [BadgeNames.Admin]);
 
-    const badges: (...badges: BadgeNames[]) => RequestHandler = (...badges) =>
-      auth(true, [...badges]);
+    // const badges: (...badges: BadgeNames[]) => RequestHandler = (...badges) =>
+    //   auth(true, [...badges]);
 
     return [
       // admin endpoints

--- a/functions/studio-api/src/services/BadgeService.ts
+++ b/functions/studio-api/src/services/BadgeService.ts
@@ -1,6 +1,6 @@
 import { NextFunction, RequestHandler, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { inject, injectable, singleton } from 'tsyringe';
+import { inject, singleton } from 'tsyringe';
 import Badge, { BadgeNames } from '../data/models/Badge';
 import User from '../data/models/User';
 import { AuthRequest, AuthService } from './Auth';

--- a/functions/studio-api/src/services/BadgeService.ts
+++ b/functions/studio-api/src/services/BadgeService.ts
@@ -1,0 +1,68 @@
+import { NextFunction, RequestHandler, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { inject, injectable, singleton } from 'tsyringe';
+import Badge, { BadgeNames } from '../data/models/Badge';
+import User from '../data/models/User';
+import { AuthRequest, AuthService } from './Auth';
+import LoggerFactory, { Logger } from './Logger';
+
+/*
+  BadgeService
+  Provides functionality and operations around App and User Badges.
+*/
+@singleton()
+export class BadgeService {
+  private logger: Logger;
+  private auth: AuthService;
+
+  constructor(
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(AuthService) auth: AuthService
+  ) {
+    this.logger = loggerFactory.getLogger(`app:services:${BadgeService.name}`);
+    this.auth = auth;
+  }
+
+  public getMiddleware(requiredBadges: BadgeNames[]): RequestHandler {
+    return async (req: AuthRequest, res: Response, next: NextFunction) => {
+      try {
+        this.logger.info('req.session: ' + req.session);
+        this.logger.info('req.user: ' + req.user);
+        if (!req.session || !req.user) {
+          this.logger.error('Not Authorized! No User Session!');
+          res.statusCode = StatusCodes.UNAUTHORIZED;
+          res.send({
+            message: 'Unauthorized',
+            statusCode: StatusCodes.UNAUTHORIZED
+          });
+          return;
+        }
+
+        if (!(await this.auth.userHasAccessBadges(req, res, requiredBadges))) {
+          return;
+        }
+
+        next();
+      } catch (err) {
+        return next(err);
+      }
+    };
+  }
+
+  public async getUserBadges(userId: number): Promise<Badge[]> {
+    const user = await User.findByPk(userId);
+    if (!user) {
+      throw new Error('Unable to resolve user from user id: ' + userId);
+    }
+    return (await user?.getBadges()) || []; // eslint-disable-line
+  }
+
+  public async getBadge(name: string): Promise<Badge | undefined> {
+    const badge = await Badge.findOne({ where: { name } });
+    return badge || undefined;
+  }
+
+  public async getBadges(): Promise<{ rows: Badge[]; count: number }> {
+    return await Badge.findAndCountAll();
+  }
+}

--- a/functions/studio-api/src/services/Google.ts
+++ b/functions/studio-api/src/services/Google.ts
@@ -4,7 +4,6 @@ import { singleton, inject, injectable } from 'tsyringe';
 import config from '../../config/google';
 import Badge, { BadgeTypes } from '../data/models/Badge';
 import User from '../data/models/User';
-import UserBadge from '../data/models/UserBadges';
 import LoggerFactory, { Logger } from './Logger';
 
 export interface GoogleUser {

--- a/functions/studio-api/src/services/Google.ts
+++ b/functions/studio-api/src/services/Google.ts
@@ -2,7 +2,9 @@ import axios, { AxiosResponse } from 'axios';
 import jwtDecode from 'jwt-decode';
 import { singleton, inject, injectable } from 'tsyringe';
 import config from '../../config/google';
+import Badge, { BadgeTypes } from '../data/models/Badge';
 import User from '../data/models/User';
+import UserBadge from '../data/models/UserBadges';
 import LoggerFactory, { Logger } from './Logger';
 
 export interface GoogleUser {
@@ -89,7 +91,8 @@ export class GoogleService {
     let user = await User.findOne({
       where: {
         sourceId: googleUser.googleId
-      }
+      },
+      include: [{ model: Badge, where: { type: BadgeTypes.Administrative } }]
     });
 
     if (!user) {

--- a/functions/studio-api/src/services/UserService.ts
+++ b/functions/studio-api/src/services/UserService.ts
@@ -1,0 +1,53 @@
+import { Includeable } from 'sequelize/types';
+import { inject, singleton } from 'tsyringe';
+import Badge, { BadgeTypes } from '../data/models/Badge';
+import User from '../data/models/User';
+import LoggerFactory, { Logger } from './Logger';
+
+export const AccessBadges: Includeable = {
+  required: false,
+  model: Badge,
+  where: {
+    type: BadgeTypes.Administrative
+  }
+};
+
+/*
+  UserService
+  Provides functionality and operations around App and User Badges.
+*/
+@singleton()
+export class UserService {
+  private logger: Logger;
+
+  constructor(@inject(LoggerFactory) loggerFactory: LoggerFactory) {
+    this.logger = loggerFactory.getLogger(`app:services:${UserService.name}`);
+  }
+
+  public async getBySourceId(userSourceId: string): Promise<User | undefined> {
+    const user = await User.findOne({
+      where: { sourceId: userSourceId },
+      include: [AccessBadges]
+    });
+
+    return user || undefined;
+  }
+
+  public async getById(userId: number): Promise<User | undefined> {
+    const user = await User.findOne({
+      where: { id: userId },
+      include: [AccessBadges]
+    });
+
+    return user || undefined;
+  }
+
+  public async getUserProfile(userId: number): Promise<User | undefined> {
+    const user = await User.findOne({
+      where: { id: userId },
+      include: [Badge]
+    });
+
+    return user || undefined;
+  }
+}


### PR DESCRIPTION
### Migration

Adds Models:
- Badge
- UserBadges

Adds Data Rows:
- Administrator Badge
- UserBadges (of type 'admin') for administrators

### API

- Updates the profiles /me endpoint to provide user badge data.
- Adds new Base Class AdminEndpoint for extending for all Admin routes.
- Adds new types AdminRequest and AdminHandler for better request types in admin endpoints
- Adds endpoints:
  - BadgeEndpoint for users to fetch their own user_badges
  - AdminBadgesEndpoint for admins to fetch all badges
- Adds middleware for checking UserBadges & helper for checking Admin UserBadges
- Adds logic to main auth middleware to optionally check UserBadges as well

Two structures based on full model or JSON output:

## Full Model

`user.Badges` = array of Badge Models
&
`Badge.UserBadge` = Join table row with ids and metadata

## JSON

`user.badges`
& 
user_badge metadata and userId flattened into badge json data
