### PR TITLE
feat: osp-12 add chore lists api endpoints

### DIFF
--- a/functions/studio-api/src/data/init.ts
+++ b/functions/studio-api/src/data/init.ts
@@ -30,5 +30,5 @@ export const modelInitialization: (
   ChoreChart.hasMany(Chore, {
     foreignKey: 'chore_chart_id'
   });
-  Chore.belongsTo(ChoreChart);
+  // Chore.belongsTo(ChoreChart);
 };

--- a/functions/studio-api/src/data/init.ts
+++ b/functions/studio-api/src/data/init.ts
@@ -26,4 +26,9 @@ export const modelInitialization: (
     through: UserBadge,
     foreignKey: 'user_id'
   });
+
+  ChoreChart.hasMany(Chore, {
+    foreignKey: 'chore_chart_id'
+  });
+  Chore.belongsTo(ChoreChart);
 };

--- a/functions/studio-api/src/data/init.ts
+++ b/functions/studio-api/src/data/init.ts
@@ -27,7 +27,13 @@ export const modelInitialization: (
     foreignKey: 'user_id'
   });
   ChoreChart.hasMany(Chore, {
-    foreignKey: 'chore_chart_id',
+    foreignKey: 'choreChartId',
+    as: 'chores',
+    onDelete: 'CASCADE'
+  });
+  Chore.hasMany(ChoreChartEvent, {
+    foreignKey: 'choreId',
+    as: 'events',
     onDelete: 'CASCADE'
   });
 };

--- a/functions/studio-api/src/data/init.ts
+++ b/functions/studio-api/src/data/init.ts
@@ -26,9 +26,8 @@ export const modelInitialization: (
     through: UserBadge,
     foreignKey: 'user_id'
   });
-
   ChoreChart.hasMany(Chore, {
-    foreignKey: 'chore_chart_id'
+    foreignKey: 'chore_chart_id',
+    onDelete: 'CASCADE'
   });
-  // Chore.belongsTo(ChoreChart);
 };

--- a/functions/studio-api/src/data/migrations/20220620191016-AddUserTable.ts
+++ b/functions/studio-api/src/data/migrations/20220620191016-AddUserTable.ts
@@ -11,7 +11,7 @@ export default {
           {
             id: {
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               autoIncrement: true
             },
             provider: {

--- a/functions/studio-api/src/data/migrations/20220708155325-AddingSessionTable.ts
+++ b/functions/studio-api/src/data/migrations/20220708155325-AddingSessionTable.ts
@@ -15,7 +15,7 @@ export default {
           },
           userId: {
             allowNull: false,
-            type: DataTypes.INTEGER,
+            type: DataTypes.BIGINT,
             references: {
               model: 'users',
               key: 'id'

--- a/functions/studio-api/src/data/migrations/20220908075756-AddUserBadges.ts
+++ b/functions/studio-api/src/data/migrations/20220908075756-AddUserBadges.ts
@@ -18,7 +18,7 @@ export default {
           {
             id: {
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               autoIncrement: true
             },
             type: {
@@ -66,7 +66,7 @@ export default {
           {
             user_id: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               primaryKey: true,
               references: {
                 model: 'users',
@@ -77,7 +77,7 @@ export default {
             badge_id: {
               allowNull: false,
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               references: {
                 model: 'badges',
                 key: 'id'

--- a/functions/studio-api/src/data/migrations/20220918015706-GrantAdminUsersBadges.ts
+++ b/functions/studio-api/src/data/migrations/20220918015706-GrantAdminUsersBadges.ts
@@ -41,7 +41,7 @@ export default {
         // GRANT ADMIN BADGES
         const initialAdmins = process.env.OS_ADMIN_USERS;
         if (initialAdmins) {
-          const admins: Array<{ id: number }> =
+          const admins: Array<{ id: string }> =
             await await queryInterface.sequelize.query(
               `SELECT id from users WHERE source_id IN (${initialAdmins})`,
               {
@@ -50,7 +50,7 @@ export default {
               }
             );
 
-          const badges: Array<{ id: number }> =
+          const badges: Array<{ id: string }> =
             await await queryInterface.sequelize.query(
               `SELECT b.id from badges b WHERE b.name = 'admin' LIMIT 1`,
               {

--- a/functions/studio-api/src/data/migrations/20221116185453-AddChoreListTables.ts
+++ b/functions/studio-api/src/data/migrations/20221116185453-AddChoreListTables.ts
@@ -12,13 +12,13 @@ export default {
           {
             id: {
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               unique: true,
               autoIncrement: true
             },
             assignee: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               primaryKey: true,
               references: {
                 model: 'users',
@@ -27,7 +27,7 @@ export default {
             },
             createdBy: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               primaryKey: true,
               references: {
                 model: 'users',
@@ -78,13 +78,13 @@ export default {
           {
             id: {
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               unique: true,
               autoIncrement: true
             },
             choreChartId: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               onDelete: 'CASCADE',
               references: {
                 model: 'chore_charts',
@@ -122,12 +122,12 @@ export default {
           {
             id: {
               primaryKey: true,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               autoIncrement: true
             },
             choreChartId: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               onDelete: 'CASCADE',
               references: {
                 model: 'chore_charts',
@@ -137,7 +137,7 @@ export default {
             },
             choreId: {
               allowNull: false,
-              type: DataTypes.INTEGER,
+              type: DataTypes.BIGINT,
               onDelete: 'CASCADE',
               references: {
                 model: 'chores',

--- a/functions/studio-api/src/data/migrations/20221116185453-AddChoreListTables.ts
+++ b/functions/studio-api/src/data/migrations/20221116185453-AddChoreListTables.ts
@@ -85,6 +85,7 @@ export default {
             choreChartId: {
               allowNull: false,
               type: DataTypes.INTEGER,
+              onDelete: 'CASCADE',
               references: {
                 model: 'chore_charts',
                 key: 'id'
@@ -127,6 +128,7 @@ export default {
             choreChartId: {
               allowNull: false,
               type: DataTypes.INTEGER,
+              onDelete: 'CASCADE',
               references: {
                 model: 'chore_charts',
                 key: 'id'
@@ -136,6 +138,7 @@ export default {
             choreId: {
               allowNull: false,
               type: DataTypes.INTEGER,
+              onDelete: 'CASCADE',
               references: {
                 model: 'chores',
                 key: 'id'

--- a/functions/studio-api/src/data/models/Badge.ts
+++ b/functions/studio-api/src/data/models/Badge.ts
@@ -2,7 +2,7 @@ import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
 import UserBadge from './UserBadges';
 
 interface BadgeAttributes {
-  id: number;
+  id: string;
   rarity: number; // 1 to 5, 5 is rarest, 1 is common
   name: string; // unique identifier used to check against in the code
   friendlyName: string;
@@ -23,7 +23,7 @@ export interface BadgeOutput
   // merged user_badge attributes if they exist
   obtained?: Date;
   unread?: boolean;
-  userId?: number;
+  userId?: string;
 }
 
 export interface BadgeInput
@@ -45,7 +45,7 @@ export class Badge
   extends Model<BadgeAttributes, BadgeInput>
   implements BadgeAttributes
 {
-  declare readonly id: number;
+  declare readonly id: string;
   declare _type: string;
   declare rarity: number;
   declare name: string;
@@ -97,7 +97,7 @@ export class Badge
       {
         id: {
           primaryKey: true,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           autoIncrement: true
         },
         type: {

--- a/functions/studio-api/src/data/models/Chore.ts
+++ b/functions/studio-api/src/data/models/Chore.ts
@@ -1,8 +1,7 @@
-import { DataTypes, Model, Sequelize } from 'sequelize';
-import User from './User';
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
 
 interface ChoreAttributes {
-  id: string;
+  id: number;
   choreChartId: number;
   name: string;
   description: string;
@@ -14,16 +13,15 @@ interface ChoreAttributes {
 // don't return these values in responses
 const PROTECTED_ATTRIBUTES: Array<keyof ChoreAttributes> = [];
 
-export interface ChoreOutput
-  extends Omit<ChoreAttributes, 'hash' | 'salt' | 'iterations'> {}
-
-export interface ChoreInput extends ChoreAttributes {}
+export interface ChoreOutput extends ChoreAttributes {}
+export interface ChoreInput
+  extends Optional<ChoreAttributes, 'created' | 'updated' | 'id'> {}
 
 export class Chore
   extends Model<ChoreAttributes, ChoreInput>
   implements ChoreAttributes
 {
-  declare id: string;
+  declare id: number;
   declare choreChartId: number;
   declare name: string;
   declare description: string;

--- a/functions/studio-api/src/data/models/Chore.ts
+++ b/functions/studio-api/src/data/models/Chore.ts
@@ -1,8 +1,8 @@
 import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
 
 interface ChoreAttributes {
-  id: number;
-  choreChartId: number;
+  id: string;
+  choreChartId: string;
   name: string;
   description: string;
   scheduleDays: string;
@@ -21,8 +21,8 @@ export class Chore
   extends Model<ChoreAttributes, ChoreInput>
   implements ChoreAttributes
 {
-  declare id: number;
-  declare choreChartId: number;
+  declare id: string;
+  declare choreChartId: string;
   declare name: string;
   declare description: string;
   declare scheduleDays: string;

--- a/functions/studio-api/src/data/models/Chore.ts
+++ b/functions/studio-api/src/data/models/Chore.ts
@@ -1,4 +1,5 @@
 import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+import ChoreChartEvent from './ChoreChartEvent';
 
 interface ChoreAttributes {
   id: string;
@@ -6,6 +7,7 @@ interface ChoreAttributes {
   name: string;
   description: string;
   scheduleDays: string;
+  events?: ChoreChartEvent[];
   created: Date;
   updated: Date;
 }
@@ -33,13 +35,17 @@ export class Chore
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
 
+  declare readonly events: ChoreChartEvent[];
+
   public toJSON(): ChoreOutput {
     // hide protected fields
-    const ChoreJson: ChoreAttributes = Object.assign({}, this.get());
+    const choreJson: ChoreAttributes = Object.assign({}, this.get());
     for (const attr of PROTECTED_ATTRIBUTES) {
-      delete ChoreJson[attr];
+      delete choreJson[attr];
     }
-    return ChoreJson;
+    return Object.assign(choreJson, {
+      events: (choreJson.events || []).map((ev) => ev.toJSON())
+    });
   }
 
   public static register(sequelize: Sequelize) {

--- a/functions/studio-api/src/data/models/Chore.ts
+++ b/functions/studio-api/src/data/models/Chore.ts
@@ -54,6 +54,7 @@ export class Chore
         choreChartId: {
           allowNull: false,
           type: DataTypes.INTEGER,
+          onDelete: 'CASCADE',
           references: {
             model: 'chore_charts',
             key: 'id'

--- a/functions/studio-api/src/data/models/ChoreChart.ts
+++ b/functions/studio-api/src/data/models/ChoreChart.ts
@@ -45,7 +45,7 @@ export class ChoreChart
   declare Chores: Array<Chore>;
 
   public async updateStreak(): Promise<void> {
-    const streakSoFar: number = this.streak;
+    // const streakSoFar: number = this.streak;
     // TODO: update streak based on the percentage of completed chore_chart_events from last cycle
     // and the ranking of each event
     await this.save();

--- a/functions/studio-api/src/data/models/ChoreChart.ts
+++ b/functions/studio-api/src/data/models/ChoreChart.ts
@@ -1,8 +1,9 @@
-import { DataTypes, Model, Sequelize } from 'sequelize';
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+import Chore from './Chore';
 import User from './User';
 
 interface ChoreChartAttributes {
-  id: string;
+  id: number;
   assignee: number;
   createdBy: number;
   name: string;
@@ -18,16 +19,18 @@ interface ChoreChartAttributes {
 // don't return these values in responses
 const PROTECTED_ATTRIBUTES: Array<keyof ChoreChartAttributes> = [];
 
-export interface ChoreChartOutput
-  extends Omit<ChoreChartAttributes, 'hash' | 'salt' | 'iterations'> {}
-
-export interface ChoreChartInput extends ChoreChartAttributes {}
+export interface ChoreChartOutput extends ChoreChartAttributes {}
+export interface ChoreChartInput
+  extends Optional<
+    ChoreChartAttributes,
+    'streak' | 'score' | 'recurring' | 'created' | 'updated' | 'id'
+  > {}
 
 export class ChoreChart
   extends Model<ChoreChartAttributes, ChoreChartInput>
   implements ChoreChartAttributes
 {
-  declare id: string;
+  declare id: number;
   declare assignee: number;
   declare createdBy: number;
   declare name: string;
@@ -39,8 +42,7 @@ export class ChoreChart
   declare created: Date;
   declare updated: Date;
 
-  declare readonly createdAt: Date;
-  declare readonly updatedAt: Date;
+  declare Chores: Array<Chore>;
 
   public async updateStreak(): Promise<void> {
     const streakSoFar: number = this.streak;

--- a/functions/studio-api/src/data/models/ChoreChart.ts
+++ b/functions/studio-api/src/data/models/ChoreChart.ts
@@ -3,9 +3,9 @@ import Chore from './Chore';
 import User from './User';
 
 interface ChoreChartAttributes {
-  id: number;
+  id: string;
   assignee: number;
-  createdBy: number;
+  createdBy: string;
   name: string;
   description: string;
   streak: number;
@@ -30,9 +30,9 @@ export class ChoreChart
   extends Model<ChoreChartAttributes, ChoreChartInput>
   implements ChoreChartAttributes
 {
-  declare id: number;
+  declare id: string;
   declare assignee: number;
-  declare createdBy: number;
+  declare createdBy: string;
   declare name: string;
   declare description: string;
   declare streak: number;
@@ -65,18 +65,18 @@ export class ChoreChart
       {
         id: {
           primaryKey: true,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           unique: true,
           autoIncrement: true
         },
         assignee: {
           allowNull: false,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           references: { model: User, key: 'id' }
         },
         createdBy: {
           allowNull: false,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           references: { model: User, key: 'id' },
           field: 'created_by'
         },

--- a/functions/studio-api/src/data/models/ChoreChart.ts
+++ b/functions/studio-api/src/data/models/ChoreChart.ts
@@ -4,7 +4,7 @@ import User from './User';
 
 interface ChoreChartAttributes {
   id: string;
-  assignee: number;
+  assignee: string;
   createdBy: string;
   name: string;
   description: string;
@@ -12,6 +12,7 @@ interface ChoreChartAttributes {
   score: number;
   recurring: boolean;
   dueTime: string;
+  chores?: Array<Chore>;
   created: Date;
   updated: Date;
 }
@@ -31,7 +32,7 @@ export class ChoreChart
   implements ChoreChartAttributes
 {
   declare id: string;
-  declare assignee: number;
+  declare assignee: string;
   declare createdBy: string;
   declare name: string;
   declare description: string;
@@ -42,7 +43,7 @@ export class ChoreChart
   declare created: Date;
   declare updated: Date;
 
-  declare Chores: Array<Chore>;
+  declare readonly chores: Array<Chore>;
 
   public async updateStreak(): Promise<void> {
     // const streakSoFar: number = this.streak;

--- a/functions/studio-api/src/data/models/ChoreChartEvent.ts
+++ b/functions/studio-api/src/data/models/ChoreChartEvent.ts
@@ -1,13 +1,20 @@
-import { DataTypes, Model, Sequelize } from 'sequelize';
+import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
+
+export enum ChoreEventStatus {
+  TODO = 'TODO',
+  NEEDS_CHECK = 'NEEDS_CHECK',
+  COMPLETED = 'COMPLETED'
+}
 
 interface ChoreChartEventAttributes {
   id: string;
   choreChartId: number;
   choreId: number;
-  status: string;
+  status: ChoreEventStatus;
+  _status?: string;
   rating: number;
   due: Date;
-  completed: Date;
+  completed?: Date;
   created: Date;
   updated: Date;
 }
@@ -15,10 +22,12 @@ interface ChoreChartEventAttributes {
 // don't return these values in responses
 const PROTECTED_ATTRIBUTES: Array<keyof ChoreChartEventAttributes> = [];
 
-export interface ChoreChartEventOutput
-  extends Omit<ChoreChartEventAttributes, 'hash' | 'salt' | 'iterations'> {}
-
-export interface ChoreChartEventInput extends ChoreChartEventAttributes {}
+export interface ChoreChartEventOutput extends ChoreChartEventAttributes {}
+export interface ChoreChartEventInput
+  extends Optional<
+    ChoreChartEventAttributes,
+    'id' | 'status' | 'rating' | 'created' | 'updated'
+  > {}
 
 export class ChoreChartEvent
   extends Model<ChoreChartEventAttributes, ChoreChartEventInput>
@@ -27,7 +36,7 @@ export class ChoreChartEvent
   declare id: string;
   declare choreChartId: number;
   declare choreId: number;
-  declare status: string;
+  declare _status: string;
   declare rating: number;
   declare due: Date;
   declare completed: Date;
@@ -37,11 +46,23 @@ export class ChoreChartEvent
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
 
+  public get status(): ChoreEventStatus {
+    return this._status as ChoreEventStatus;
+  }
+
+  public set status(badgeType: ChoreEventStatus) {
+    this._status = badgeType?.toString();
+  }
+
   public toJSON(): ChoreChartEventOutput {
     // hide protected fields
     const ChoreChartEventJson: ChoreChartEventAttributes = Object.assign(
       {},
-      this.get()
+      this.get(),
+      {
+        status: this._status,
+        _status: undefined
+      }
     );
     for (const attr of PROTECTED_ATTRIBUTES) {
       delete ChoreChartEventJson[attr];
@@ -60,6 +81,7 @@ export class ChoreChartEvent
         choreChartId: {
           allowNull: false,
           type: DataTypes.INTEGER,
+          onDelete: 'CASCADE',
           references: {
             model: 'chore_charts',
             key: 'id'
@@ -70,6 +92,7 @@ export class ChoreChartEvent
           allowNull: false,
           type: DataTypes.INTEGER,
           primaryKey: true,
+          onDelete: 'CASCADE',
           references: {
             model: 'chores',
             key: 'id'
@@ -77,7 +100,11 @@ export class ChoreChartEvent
           field: 'chore_id'
         },
         status: {
-          type: DataTypes.STRING
+          type: DataTypes.VIRTUAL
+        },
+        _status: {
+          type: DataTypes.STRING,
+          field: 'status'
         },
         rating: {
           type: DataTypes.INTEGER,

--- a/functions/studio-api/src/data/models/ChoreChartEvent.ts
+++ b/functions/studio-api/src/data/models/ChoreChartEvent.ts
@@ -8,8 +8,8 @@ export enum ChoreEventStatus {
 
 interface ChoreChartEventAttributes {
   id: string;
-  choreChartId: number;
-  choreId: number;
+  choreChartId: string;
+  choreId: string;
   status: ChoreEventStatus;
   _status?: string;
   rating: number;
@@ -34,8 +34,8 @@ export class ChoreChartEvent
   implements ChoreChartEventAttributes
 {
   declare id: string;
-  declare choreChartId: number;
-  declare choreId: number;
+  declare choreChartId: string;
+  declare choreId: string;
   declare _status: string;
   declare rating: number;
   declare due: Date;
@@ -75,12 +75,12 @@ export class ChoreChartEvent
       {
         id: {
           primaryKey: true,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           autoIncrement: true
         },
         choreChartId: {
           allowNull: false,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           onDelete: 'CASCADE',
           references: {
             model: 'chore_charts',
@@ -90,7 +90,7 @@ export class ChoreChartEvent
         },
         choreId: {
           allowNull: false,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           primaryKey: true,
           onDelete: 'CASCADE',
           references: {

--- a/functions/studio-api/src/data/models/Session.ts
+++ b/functions/studio-api/src/data/models/Session.ts
@@ -3,7 +3,7 @@ import User from './User';
 
 interface SessionAttributes {
   id: string;
-  userId: number;
+  userId: string;
   hash: string;
   salt: string;
   iterations: number;
@@ -29,7 +29,7 @@ export class Session
   implements SessionAttributes
 {
   declare id: string;
-  declare userId: number;
+  declare userId: string;
   declare hash: string;
   declare salt: string;
   declare iterations: number;
@@ -63,7 +63,7 @@ export class Session
         },
         userId: {
           allowNull: false,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           references: { model: User, key: 'id' },
           field: 'user_id'
         },

--- a/functions/studio-api/src/data/models/User.ts
+++ b/functions/studio-api/src/data/models/User.ts
@@ -2,8 +2,18 @@ import { DataTypes, Model, Optional, Sequelize } from 'sequelize';
 import { EncryptUtil } from '../../utilities/EncryptUtil';
 import Badge, { BadgeOutput } from './Badge';
 
+// Note About model IDs in this project:
+// The IDs in production are big.
+// Our prod db uses 64 bits (not 32) for the DataTypes.INTEGER type.
+// We mark all our ids with BIGINT to match prod behavior since the
+// auto generated values for IDs usually start over 32 bits. We also treat
+// the properties as strings to avoid silly arithmetic mistakes.
+//
+// Just note that any INTEGER columns should use caution that the field can
+// grow to numbers larger than Number.MAX_SAFE_INTEGER in production.
+
 export interface UserAttributes {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -41,7 +51,7 @@ export class User
   extends Model<UserAttributes, UserInput>
   implements UserAttributes
 {
-  declare id: number;
+  declare id: string;
   declare firstName: string;
   declare lastName: string;
   declare email: string;
@@ -117,7 +127,7 @@ export class User
       {
         id: {
           primaryKey: true,
-          type: DataTypes.INTEGER,
+          type: DataTypes.BIGINT,
           autoIncrement: true
         },
         provider: {

--- a/functions/studio-api/src/data/models/UserBadges.ts
+++ b/functions/studio-api/src/data/models/UserBadges.ts
@@ -4,8 +4,8 @@ interface UserBadgeAttributes {
   unread: boolean;
   created: Date;
   updated: Date;
-  user_id: number;
-  badge_id: number;
+  user_id: string;
+  badge_id: string;
 }
 
 // don't return these values in responses. The updated field is required so
@@ -23,8 +23,8 @@ export class UserBadge
 {
   declare readonly created: Date;
   declare readonly updated: Date;
-  declare readonly user_id: number;
-  declare readonly badge_id: number;
+  declare readonly user_id: string;
+  declare readonly badge_id: string;
   declare unread: boolean;
 
   public toJSON(): UserBadgeOutput {
@@ -45,8 +45,8 @@ export class UserBadge
         },
         created: { type: DataTypes.DATE },
         updated: { type: DataTypes.DATE },
-        user_id: { type: DataTypes.INTEGER },
-        badge_id: { type: DataTypes.INTEGER }
+        user_id: { type: DataTypes.BIGINT },
+        badge_id: { type: DataTypes.BIGINT }
       },
       {
         sequelize,

--- a/functions/studio-api/src/routes/UserChoresEndpoint.ts
+++ b/functions/studio-api/src/routes/UserChoresEndpoint.ts
@@ -1,0 +1,137 @@
+import { StatusCodes } from 'http-status-codes';
+import _ from 'lodash';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import ChoreChart, { ChoreChartOutput } from '../data/models/ChoreChart';
+import ChoreChartEvent, {
+  ChoreEventStatus
+} from '../data/models/ChoreChartEvent';
+import { AuthRequest } from '../services/Auth';
+import { ChoreService } from '../services/ChoreService';
+import LoggerFactory from '../services/Logger';
+import ErrorResponse from '../utilities/ErrorResponse';
+import { Paged } from '../utilities/Pagination';
+import BaseEndpoint, { RouterClass } from './BaseEndpoint';
+
+@injectable()
+export class UserChoresEndpoint extends BaseEndpoint implements RouterClass {
+  private choreService: ChoreService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(ChoreService) choreService: ChoreService
+  ) {
+    super(harness, loggerFactory);
+    this.choreService = choreService;
+  }
+
+  public mountRoutes() {
+    this.router.get('/', this.getUserChores.bind(this));
+    this.router.patch('/', this.patchChore.bind(this));
+  }
+
+  async patchChore(req: AuthRequest) {
+    if (!req.body.eventId) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing required field in body: eventId'
+      );
+    }
+    if (!req.body.status) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing required field in body: status'
+      );
+    }
+
+    const choreEvent = await ChoreChartEvent.findByPk(req.body.eventId);
+    if (!choreEvent) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find event with id ${req.body.eventId}`
+      );
+    }
+    const chart = await ChoreChart.findByPk(choreEvent.choreChartId);
+    if (!chart) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chart from event id ${req.body.eventId} ` +
+          `and chart id ${choreEvent.choreChartId}`
+      );
+    }
+
+    if (req.user?.id !== chart.assignee) {
+      throw new ErrorResponse(
+        StatusCodes.FORBIDDEN,
+        `Unable to access event with id ${req.body.eventId}`
+      );
+    }
+
+    // allow updating the status
+    const status = this.resolveEventStatus(req.body.status);
+    if (
+      choreEvent.status !== status &&
+      choreEvent.status !== ChoreEventStatus.COMPLETED
+    ) {
+      this.logger.info(
+        `Updating chore event ${req.body.eventId} to status ${status}`
+      );
+      choreEvent.status = status;
+      choreEvent._status = status.toString();
+      await choreEvent.save();
+    }
+
+    return choreEvent.toJSON();
+  }
+
+  async getUserChores(req: AuthRequest): Promise<Paged<ChoreChartOutput>> {
+    if (!req.user) {
+      throw new ErrorResponse(
+        StatusCodes.UNAUTHORIZED,
+        'Request is missing user session data!'
+      );
+    }
+
+    // ensure we have an authenticated user
+    if (!req.user?.id) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        'Unable to find user with id: ' + req.user?.id
+      );
+    }
+
+    const choreCharts = await this.choreService.getCurrentChoresForUser(
+      req.user.id
+    );
+    const hasEvents = choreCharts.results.some(({ chores }) => {
+      return _.flatMap(chores, ({ events }) => events).length > 0;
+    });
+
+    // return the data if events have already been created
+    if (hasEvents) {
+      return choreCharts;
+    }
+
+    // otherwise create events for this and return the refreshed data
+    await this.choreService.createAssigneeEventsIfNeeded(req.user.id);
+    return await this.choreService.getCurrentChoresForUser(req.user.id);
+  }
+
+  private resolveEventStatus(status: string): ChoreEventStatus {
+    switch (status.toUpperCase()) {
+      // assignees can only toggle between the two states
+      case ChoreEventStatus.NEEDS_CHECK.toString():
+        return ChoreEventStatus.NEEDS_CHECK;
+      case ChoreEventStatus.TODO.toString():
+        return ChoreEventStatus.TODO;
+      default:
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          `Bad input for status: ${status}`
+        );
+    }
+  }
+}
+
+export default UserChoresEndpoint;

--- a/functions/studio-api/src/routes/UsersEndpoint.ts
+++ b/functions/studio-api/src/routes/UsersEndpoint.ts
@@ -1,0 +1,48 @@
+import { StatusCodes } from 'http-status-codes';
+import _ from 'lodash';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import User from '../data/models/User';
+import { AuthRequest } from '../services/Auth';
+import LoggerFactory from '../services/Logger';
+import { UserService } from '../services/UserService';
+import ErrorResponse from '../utilities/ErrorResponse';
+import { Paged, pagingFromRequest } from '../utilities/Pagination';
+import BaseEndpoint, { RouterClass } from './BaseEndpoint';
+
+@injectable()
+export class UsersEndpoint extends BaseEndpoint implements RouterClass {
+  private userService: UserService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(UserService) userService: UserService
+  ) {
+    super(harness, loggerFactory);
+    this.userService = userService;
+  }
+
+  public mountRoutes() {
+    this.router.get('/', this.getUsers.bind(this));
+  }
+
+  async getUsers(req: AuthRequest) {
+    const paging = pagingFromRequest(req);
+    if (!!paging.errorMessage) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
+    }
+
+    // fetch users and restrict the fields returned
+    const users = await this.userService.getUsers();
+    const result: Paged<Partial<User>> = Object.assign({}, users, {
+      results: users.results.map((u) =>
+        _.pick(u, ['id', 'firstName', 'lastName', 'email', 'avatar'])
+      )
+    });
+
+    return result;
+  }
+}
+
+export default UsersEndpoint;

--- a/functions/studio-api/src/routes/UsersEndpoint.ts
+++ b/functions/studio-api/src/routes/UsersEndpoint.ts
@@ -29,7 +29,7 @@ export class UsersEndpoint extends BaseEndpoint implements RouterClass {
 
   async getUsers(req: AuthRequest) {
     const paging = pagingFromRequest(req);
-    if (!!paging.errorMessage) {
+    if (paging.errorMessage) {
       throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
     }
 

--- a/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/AdminBadgesEndpoint.ts
@@ -7,6 +7,7 @@ import { BadgeService } from '../../services/BadgeService';
 import ErrorResponse from '../../utilities/ErrorResponse';
 import { RouterClass } from './../BaseEndpoint';
 import AdminEndpoint, { isAdminRequest } from './AdminEndpoint';
+import { pagingFromRequest } from '../../utilities/Pagination';
 
 @injectable()
 export class AdminBadgesEndpoint extends AdminEndpoint implements RouterClass {
@@ -26,14 +27,13 @@ export class AdminBadgesEndpoint extends AdminEndpoint implements RouterClass {
     this.router.get('/', this.getBadges.bind(this));
   }
 
-  async getBadges() {
-    try {
-      this.logger.info('fetching all badges');
-      return await this.badgeService.getBadges();
-    } catch (err) {
-      this.logger.error(err);
-      return [];
+  async getBadges(req: AdminRequest) {
+    this.logger.info('fetching all badges');
+    const paging = pagingFromRequest(req);
+    if (paging.errorMessage) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
     }
+    return await this.badgeService.getBadges(paging);
   }
 
   async getBadgeByType(req: AdminRequest) {

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
@@ -34,7 +34,6 @@ export class ChoreChartEventsEndpoint
   public mountRoutes() {
     // base = '/admin/chore-charts'
     this.router.get('/:chartId/events', this.getChoreChartEvents.bind(this));
-
     this.router.patch(
       '/:chartId/events/:eventId',
       this.patchChoreChartEvents.bind(this)
@@ -128,7 +127,9 @@ export class ChoreChartEventsEndpoint
 
     // status can change
     if (req.body.status) {
-      chartEvent.status = this.resolveEventStatus(req.body.status);
+      const status = this.resolveEventStatus(req.body.status);
+      chartEvent.status = status;
+      chartEvent._status = status.toString();
     }
 
     // rating can change
@@ -138,6 +139,12 @@ export class ChoreChartEventsEndpoint
         throw new ErrorResponse(
           StatusCodes.BAD_REQUEST,
           `Invalid input for rating: ${req.body.rating}`
+        );
+      }
+      if (newRating > 5 || newRating < 0) {
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          `Bad input for rating field: ${newRating}`
         );
       }
       chartEvent.rating = newRating;

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
@@ -76,8 +76,10 @@ export class ChoreChartEventsEndpoint
       switch (req.query.filter) {
         case 'today':
           sinceDate = moment().startOf('day').toDate();
+          break;
         case 'week':
           sinceDate = moment().startOf('week').toDate();
+          break;
         default:
           this.logger.info(
             `Ignoring unsupported filter type in query params: ${req.query.filter}`

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
@@ -1,0 +1,197 @@
+import { StatusCodes } from 'http-status-codes';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import { AdminRequest } from '../../../services/Auth';
+import LoggerFactory from '../../../services/Logger';
+import { ChoreService } from '../../../services/ChoreService';
+import ErrorResponse from '../../../utilities/ErrorResponse';
+import { RouterClass } from '../../BaseEndpoint';
+import AdminEndpoint from '../AdminEndpoint';
+import ChoreChartEvents, {
+  ChoreChartEventOutput,
+  ChoreEventStatus
+} from '../../../data/models/ChoreChartEvent';
+import { Paged, pagingFromRequest } from '../../../utilities/Pagination';
+import moment from 'moment';
+import ChoreChart from '../../../data/models/ChoreChart';
+
+@injectable()
+export class ChoreChartEventsEndpoint
+  extends AdminEndpoint
+  implements RouterClass
+{
+  private choreService: ChoreService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(ChoreService) choreService: ChoreService
+  ) {
+    super(harness, loggerFactory);
+    this.choreService = choreService;
+  }
+
+  public mountRoutes() {
+    // base = '/admin/chore-charts'
+    this.router.get('/:chartId/events', this.getChoreChartEvents.bind(this));
+
+    this.router.patch(
+      '/:chartId/events/:eventId',
+      this.patchChoreChartEvents.bind(this)
+    );
+  }
+
+  /*
+    Fetch all ChoreChartEvents
+  */
+  async getChoreChartEvents(
+    req: AdminRequest
+  ): Promise<Paged<ChoreChartEventOutput>> {
+    this.logger.info('fetching charts...');
+    const paging = pagingFromRequest(req);
+    if (paging.errorMessage) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
+    }
+
+    // check chart exists and authenticated user is the owner
+    const chartId = this.getChartId(req);
+    const chart = await ChoreChart.findByPk(chartId);
+    if (!chart || chart.createdBy !== req.user?.id) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chart with owner id ${req.user?.id} and chart id ${chartId}`
+      );
+    }
+
+    // attempt to create
+    const eventsCreated = await this.choreService.createChoreEventsIfNeeded(
+      chartId
+    );
+    if (eventsCreated) {
+      this.logger.info(`Created chore chart ${chartId} events for this week`);
+    }
+
+    let sinceDate: Date | undefined;
+    if (req.query.filter) {
+      switch (req.query.filter) {
+        case 'today':
+          sinceDate = moment().startOf('day').toDate();
+        case 'week':
+          sinceDate = moment().startOf('week').toDate();
+        default:
+          this.logger.info(
+            `Ignoring unsupported filter type in query params: ${req.query.filter}`
+          );
+      }
+    }
+    return await this.choreService.getChartEventsForOwner(
+      chartId,
+      sinceDate,
+      paging
+    );
+  }
+
+  /*
+    Update a ChoreChartEvents with a partial model
+  */
+  async patchChoreChartEvents(
+    req: AdminRequest
+  ): Promise<ChoreChartEventOutput> {
+    if (!req.params.chartId || isNaN(parseInt(req.params.chartId, 10))) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing or bad endpoint param: chartId'
+      );
+    }
+    if (!req.params.eventId || isNaN(parseInt(req.params.eventId, 10))) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing or bad endpoint param: eventId'
+      );
+    }
+
+    const chartId: number = this.getChartId(req);
+    const eventId: number = parseInt(req.params.eventId, 10);
+
+    this.logger.info('patching chore chart with chartId' + chartId);
+    const chart = await ChoreChart.findByPk(chartId);
+    if (!chart || chart.createdBy !== req.user?.id) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chart with owner id ${req.user?.id} and chart id ${chartId}`
+      );
+    }
+
+    const chartEvent = await ChoreChartEvents.findByPk(eventId);
+    if (!chartEvent) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chore-chart-event with id: ${eventId}`
+      );
+    }
+
+    // status can change
+    if (req.body.status) {
+      chartEvent.status = this.resolveEventStatus(req.body.status);
+    }
+
+    // rating can change
+    if (req.body.rating) {
+      const newRating = parseInt(req.body.rating, 10);
+      if (isNaN(newRating)) {
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          `Invalid input for rating: ${req.body.rating}`
+        );
+      }
+      chartEvent.rating = newRating;
+    }
+
+    // update and return the event
+    await chartEvent.save();
+    return chartEvent.toJSON();
+  }
+
+  public resolveEventStatus(status: string): ChoreEventStatus {
+    switch (status.toUpperCase()) {
+      case ChoreEventStatus.COMPLETED.toString():
+        return ChoreEventStatus.COMPLETED;
+      case ChoreEventStatus.NEEDS_CHECK.toString():
+        return ChoreEventStatus.NEEDS_CHECK;
+      case ChoreEventStatus.TODO.toString():
+        return ChoreEventStatus.TODO;
+      default:
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          `Bad input for status: ${status}`
+        );
+    }
+  }
+
+  private getChartId(req: AdminRequest): number {
+    if (!req.params.chartId) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing request param: chartId'
+      );
+    }
+
+    let chartId: number | undefined;
+    try {
+      chartId = parseInt(req.params.chartId, 10);
+      if (isNaN(chartId)) {
+        throw new Error('Invalid number for chartId: ' + req.params.chartId);
+      }
+    } catch (err) {
+      this.logger.error('Error parsing chartId: ' + req.params.chartId);
+      this.logger.error(err);
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Invalid chartId URL parameter'
+      );
+    }
+    return chartId;
+  }
+}
+
+export default ChoreChartEventsEndpoint;

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartEventsEndpoint.ts
@@ -99,21 +99,15 @@ export class ChoreChartEventsEndpoint
   async patchChoreChartEvents(
     req: AdminRequest
   ): Promise<ChoreChartEventOutput> {
-    if (!req.params.chartId || isNaN(parseInt(req.params.chartId, 10))) {
-      throw new ErrorResponse(
-        StatusCodes.BAD_REQUEST,
-        'Missing or bad endpoint param: chartId'
-      );
-    }
-    if (!req.params.eventId || isNaN(parseInt(req.params.eventId, 10))) {
+    const chartId: string = this.getChartId(req);
+    if (!req.params.eventId) {
       throw new ErrorResponse(
         StatusCodes.BAD_REQUEST,
         'Missing or bad endpoint param: eventId'
       );
     }
 
-    const chartId: number = this.getChartId(req);
-    const eventId: number = parseInt(req.params.eventId, 10);
+    const eventId: string = req.params.eventId;
 
     this.logger.info('patching chore chart with chartId' + chartId);
     const chart = await ChoreChart.findByPk(chartId);
@@ -170,7 +164,7 @@ export class ChoreChartEventsEndpoint
     }
   }
 
-  private getChartId(req: AdminRequest): number {
+  private getChartId(req: AdminRequest): string {
     if (!req.params.chartId) {
       throw new ErrorResponse(
         StatusCodes.BAD_REQUEST,
@@ -178,21 +172,7 @@ export class ChoreChartEventsEndpoint
       );
     }
 
-    let chartId: number | undefined;
-    try {
-      chartId = parseInt(req.params.chartId, 10);
-      if (isNaN(chartId)) {
-        throw new Error('Invalid number for chartId: ' + req.params.chartId);
-      }
-    } catch (err) {
-      this.logger.error('Error parsing chartId: ' + req.params.chartId);
-      this.logger.error(err);
-      throw new ErrorResponse(
-        StatusCodes.BAD_REQUEST,
-        'Invalid chartId URL parameter'
-      );
-    }
-    return chartId;
+    return `${req.params.chartId}`;
   }
 }
 

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
@@ -91,13 +91,13 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
     Update a ChoreChart with a partial model
   */
   async patchChoreChart(req: AdminRequest): Promise<ChoreChartOutput> {
-    if (!req.params.id || isNaN(parseInt(req.params.id, 10))) {
+    if (!req.params.id) {
       throw new ErrorResponse(
         StatusCodes.BAD_REQUEST,
         'Missing endpoint param: id'
       );
     }
-    const id: number = parseInt(`${req.params.id}`, 10);
+    const { id } = req.params;
     this.logger.info('patching chore chart with id' + id);
     const chart: ChoreChart | null = await ChoreChart.findByPk(id);
 

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
@@ -1,0 +1,190 @@
+import { StatusCodes } from 'http-status-codes';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import { AdminRequest, AuthRequest } from '../../../services/Auth';
+import LoggerFactory from '../../../services/Logger';
+import { ChoreService } from '../../../services/ChoreService';
+import ErrorResponse from '../../../utilities/ErrorResponse';
+import { RouterClass } from '../../BaseEndpoint';
+import AdminEndpoint from '../AdminEndpoint';
+import ChoreChart, {
+  ChoreChartInput,
+  ChoreChartOutput
+} from '../../../data/models/ChoreChart';
+import { Paged, pagingFromRequest } from '../../../utilities/Pagination';
+import _ from 'lodash';
+import { UserService } from '../../../services/UserService';
+
+@injectable()
+export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
+  private choreService: ChoreService;
+  private userService: UserService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(ChoreService) choreService: ChoreService,
+    @inject(UserService) userService: UserService
+  ) {
+    super(harness, loggerFactory);
+    this.choreService = choreService;
+    this.userService = userService;
+  }
+
+  public mountRoutes() {
+    this.router.get('/', this.getChoreCharts.bind(this));
+    this.router.post('/', this.createChoreChart.bind(this));
+    this.router.patch('/:id', this.patchChoreChart.bind(this));
+    this.router.delete('/:id', this.deleteChoreChart.bind(this));
+  }
+
+  /*
+    Fetch all ChoreCharts
+  */
+  async getChoreCharts(req: AdminRequest): Promise<Paged<ChoreChartOutput>> {
+    this.logger.info('fetching charts...');
+    const paging = pagingFromRequest(req);
+    if (!!paging.errorMessage) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
+    }
+    return await this.choreService.getCharts(paging);
+  }
+
+  /*
+    Create a new ChoreChart
+  */
+  async createChoreChart(req: AdminRequest): Promise<ChoreChartOutput> {
+    if (!req.user) {
+      throw new ErrorResponse(
+        StatusCodes.UNAUTHORIZED,
+        'User session data missing from request'
+      );
+    }
+
+    // ensure fields exist
+    const requiredFields = ['name', 'assignee', 'description', 'dueTime'];
+    this.throwOnMissing(req, ['name', 'assignee', 'description', 'dueTime']);
+    const existingChart = await this.choreService.getChoreChartByName(
+      req.body.name
+    );
+    if (!!existingChart) {
+      throw new ErrorResponse(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+        `Chore chart already exists with name: ${req.body.name}`
+      );
+    }
+
+    const inputData: ChoreChartInput = Object.assign(
+      {},
+      _.pick(req.body, [...requiredFields, 'recurring']),
+      {
+        createdBy: req.user.id
+      }
+    ) as ChoreChartInput;
+
+    // create the chart
+    this.logger.info('creating a new chore chart with name ' + req.body.name);
+    return (await ChoreChart.create(inputData)).toJSON();
+  }
+
+  /*
+    Update a ChoreChart with a partial model
+  */
+  async patchChoreChart(req: AdminRequest): Promise<ChoreChartOutput> {
+    if (!req.params.id || isNaN(parseInt(req.params.id, 10))) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing endpoint param: id'
+      );
+    }
+    const id: number = parseInt(`${req.params.id}`, 10);
+    this.logger.info('patching chore chart with id' + id);
+    const chart: ChoreChart | null = await ChoreChart.findByPk(id);
+
+    if (!chart) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chore-chart with id: ${id}`
+      );
+    }
+
+    // make sure no duplicate name exists
+    if (!!req.body.name) {
+      const existing = await this.choreService.getChoreChartByName(
+        req.body.name
+      );
+      if (!!existing && existing.id !== id) {
+        throw new ErrorResponse(
+          StatusCodes.UNPROCESSABLE_ENTITY,
+          `Chore chart already exists with name: ${req.body.name}`
+        );
+      }
+    }
+
+    // make sure assignee exists if provided
+    if (!!req.body.assignee) {
+      const assignee = await this.userService.getById(req.body.assignee);
+      if (!assignee) {
+        throw new ErrorResponse(
+          StatusCodes.UNPROCESSABLE_ENTITY,
+          `Unable to find user with id ${req.body.assignee} for chore-chart assignee`
+        );
+      }
+    }
+
+    // update allowed fields
+    Object.assign(
+      chart,
+      _.pick(req.body, [
+        'name',
+        'assignee',
+        'description',
+        'dueTime',
+        'streak',
+        'score',
+        'recurring'
+      ])
+    );
+    await chart.save();
+
+    // return the chart
+    return chart.toJSON();
+  }
+
+  /*
+    Delete a ChoreChart
+  */
+  public async deleteChoreChart(req: AdminRequest) {
+    if (!req.params.id) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing endpoint param: id'
+      );
+    }
+    this.logger.info('patching chore chart with id' + req.params.id);
+    const chart: ChoreChart | null = await ChoreChart.findByPk(req.params.id);
+
+    if (!chart) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chore-chart with id: ${req.params.id}`
+      );
+    }
+
+    await chart.destroy();
+    return { success: true, deleted: chart.toJSON() };
+  }
+
+  private throwOnMissing(req: AuthRequest | AdminRequest, propList: string[]) {
+    for (const prop of propList) {
+      if (!req.body[prop]) {
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          'Missing required field: ' + prop
+        );
+      }
+    }
+  }
+}
+
+export default ChoreChartsEndpoint;

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
@@ -64,6 +64,17 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
     // ensure fields exist
     const requiredFields = ['name', 'assignee', 'description', 'dueTime'];
     this.throwOnMissing(req, ['name', 'assignee', 'description', 'dueTime']);
+
+    // make sure assignee exists
+    const assignee = await this.userService.getById(req.body.assignee);
+    if (!assignee) {
+      throw new ErrorResponse(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+        `Unable to find user with id ${req.body.assignee} for chore-chart assignee`
+      );
+    }
+
+    // duplicate name check
     const existingChart = await this.choreService.getChoreChartByName(
       req.body.name
     );

--- a/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoreChartsEndpoint.ts
@@ -44,7 +44,7 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
   async getChoreCharts(req: AdminRequest): Promise<Paged<ChoreChartOutput>> {
     this.logger.info('fetching charts...');
     const paging = pagingFromRequest(req);
-    if (!!paging.errorMessage) {
+    if (paging.errorMessage) {
       throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
     }
     return await this.choreService.getCharts(paging);
@@ -67,7 +67,7 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
     const existingChart = await this.choreService.getChoreChartByName(
       req.body.name
     );
-    if (!!existingChart) {
+    if (existingChart) {
       throw new ErrorResponse(
         StatusCodes.UNPROCESSABLE_ENTITY,
         `Chore chart already exists with name: ${req.body.name}`
@@ -109,11 +109,11 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
     }
 
     // make sure no duplicate name exists
-    if (!!req.body.name) {
+    if (req.body.name) {
       const existing = await this.choreService.getChoreChartByName(
         req.body.name
       );
-      if (!!existing && existing.id !== id) {
+      if (existing && existing.id !== id) {
         throw new ErrorResponse(
           StatusCodes.UNPROCESSABLE_ENTITY,
           `Chore chart already exists with name: ${req.body.name}`
@@ -122,7 +122,7 @@ export class ChoreChartsEndpoint extends AdminEndpoint implements RouterClass {
     }
 
     // make sure assignee exists if provided
-    if (!!req.body.assignee) {
+    if (req.body.assignee) {
       const assignee = await this.userService.getById(req.body.assignee);
       if (!assignee) {
         throw new ErrorResponse(

--- a/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
@@ -1,0 +1,175 @@
+import { StatusCodes } from 'http-status-codes';
+import { HarnessDependency } from 'route-harness';
+import { inject, injectable } from 'tsyringe';
+import { AdminRequest, AuthRequest } from '../../../services/Auth';
+import LoggerFactory from '../../../services/Logger';
+import { ChoreService } from '../../../services/ChoreService';
+import ErrorResponse from '../../../utilities/ErrorResponse';
+import { RouterClass } from '../../BaseEndpoint';
+import AdminEndpoint from '../AdminEndpoint';
+import ChoreChart, { ChoreChartOutput } from '../../../data/models/ChoreChart';
+import { Paged, pagingFromRequest } from '../../../utilities/Pagination';
+import _ from 'lodash';
+import { UserService } from '../../../services/UserService';
+import Chore, { ChoreInput, ChoreOutput } from '../../../data/models/Chore';
+
+@injectable()
+export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
+  private choreService: ChoreService;
+
+  constructor(
+    @inject('RouteHarness') harness: HarnessDependency,
+    @inject(LoggerFactory) loggerFactory: LoggerFactory,
+    @inject(ChoreService) choreService: ChoreService
+  ) {
+    super(harness, loggerFactory);
+    this.choreService = choreService;
+  }
+
+  public mountRoutes() {
+    // base = '/admin/chore-charts'
+    this.router.get('/:id/chores/', this.getChores.bind(this));
+    this.router.post('/:id/chores/', this.createChore.bind(this));
+    this.router.patch('/:id/chores/:choreId', this.patchChore.bind(this));
+    this.router.delete('/:id/chores/:choreId', this.deleteChore.bind(this));
+  }
+
+  /*
+    Fetch all Chores
+  */
+  async getChores(req: AdminRequest): Promise<Paged<ChoreOutput>> {
+    this.logger.info('fetching charts...');
+    const paging = pagingFromRequest(req);
+    if (!!paging.errorMessage) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
+    }
+
+    const id = parseInt(`${req.params.id}`, 10);
+    if (isNaN(id)) {
+      throw new ErrorResponse(StatusCodes.BAD_REQUEST, 'Invalid id');
+    }
+    return await this.choreService.getChores(id, paging);
+  }
+
+  /*
+    Create a new Chore
+  */
+  async createChore(req: AdminRequest): Promise<ChoreOutput> {
+    if (!req.user) {
+      throw new ErrorResponse(
+        StatusCodes.UNAUTHORIZED,
+        'User session data missing from request'
+      );
+    }
+
+    // ensure fields exist
+    const requiredFields = ['name', 'description', 'scheduleDays'];
+    this.throwOnMissing(req, requiredFields);
+    const existingChart = await ChoreChart.findByPk(req.params.id);
+    if (!existingChart) {
+      throw new ErrorResponse(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+        `Unable to find chart with id: ${req.params.id}`
+      );
+    }
+    const existingChore = await this.choreService.getChoreByName(req.body.name);
+    if (!!existingChore) {
+      throw new ErrorResponse(
+        StatusCodes.UNPROCESSABLE_ENTITY,
+        `Chore already exists with name: ${req.body.name}`
+      );
+    }
+
+    const inputData: ChoreInput = Object.assign(
+      {},
+      _.pick(req.body, requiredFields),
+      {
+        choreChartId: existingChart.id
+      }
+    ) as ChoreInput;
+
+    // create the chart
+    this.logger.info('creating a new chore chart with name ' + req.body.name);
+    return (await Chore.create(inputData)).toJSON();
+  }
+
+  /*
+    Update a ChoreChart with a partial model
+  */
+  async patchChore(req: AdminRequest): Promise<ChoreOutput> {
+    if (!req.params.id || !req.params.choreId) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing endpoint param: id'
+      );
+    }
+    const choreId: number = parseInt(`${req.params.choreId}`, 10);
+    this.logger.info('patching chore with id' + choreId);
+    const chore: Chore | null = await Chore.findByPk(choreId);
+
+    if (!chore) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chore with id: ${choreId}`
+      );
+    }
+
+    // make sure no duplicate name exists
+    if (!!req.body.name) {
+      const existing = await this.choreService.getChoreByName(req.body.name);
+      if (!!existing && existing.id !== choreId) {
+        throw new ErrorResponse(
+          StatusCodes.UNPROCESSABLE_ENTITY,
+          `Chore already exists with name: ${req.body.name}`
+        );
+      }
+    }
+
+    // update allowed fields
+    Object.assign(
+      chore,
+      _.pick(req.body, ['choreChartId', 'name', 'description', 'scheduleDays'])
+    );
+    await chore.save();
+
+    // return the chore
+    return chore.toJSON();
+  }
+
+  /*
+    Delete a ChoreChart
+  */
+  public async deleteChore(req: AdminRequest) {
+    if (!req.params.choreId) {
+      throw new ErrorResponse(
+        StatusCodes.BAD_REQUEST,
+        'Missing endpoint param: id'
+      );
+    }
+    this.logger.info('patching chore with id' + req.params.choreId);
+    const chore: Chore | null = await Chore.findByPk(req.params.choreId);
+
+    if (!chore) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chore with id: ${req.params.choreId}`
+      );
+    }
+
+    await chore.destroy();
+    return { success: true, deleted: chore.toJSON() };
+  }
+
+  private throwOnMissing(req: AuthRequest | AdminRequest, propList: string[]) {
+    for (const prop of propList) {
+      if (!req.body[prop]) {
+        throw new ErrorResponse(
+          StatusCodes.BAD_REQUEST,
+          'Missing required field: ' + prop
+        );
+      }
+    }
+  }
+}
+
+export default ChoresEndpoint;

--- a/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
@@ -7,10 +7,9 @@ import { ChoreService } from '../../../services/ChoreService';
 import ErrorResponse from '../../../utilities/ErrorResponse';
 import { RouterClass } from '../../BaseEndpoint';
 import AdminEndpoint from '../AdminEndpoint';
-import ChoreChart, { ChoreChartOutput } from '../../../data/models/ChoreChart';
+import ChoreChart from '../../../data/models/ChoreChart';
 import { Paged, pagingFromRequest } from '../../../utilities/Pagination';
 import _ from 'lodash';
-import { UserService } from '../../../services/UserService';
 import Chore, { ChoreInput, ChoreOutput } from '../../../data/models/Chore';
 
 @injectable()
@@ -40,7 +39,7 @@ export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
   async getChores(req: AdminRequest): Promise<Paged<ChoreOutput>> {
     this.logger.info('fetching charts...');
     const paging = pagingFromRequest(req);
-    if (!!paging.errorMessage) {
+    if (paging.errorMessage) {
       throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
     }
 
@@ -73,7 +72,7 @@ export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
       );
     }
     const existingChore = await this.choreService.getChoreByName(req.body.name);
-    if (!!existingChore) {
+    if (existingChore) {
       throw new ErrorResponse(
         StatusCodes.UNPROCESSABLE_ENTITY,
         `Chore already exists with name: ${req.body.name}`
@@ -115,9 +114,9 @@ export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
     }
 
     // make sure no duplicate name exists
-    if (!!req.body.name) {
+    if (req.body.name) {
       const existing = await this.choreService.getChoreByName(req.body.name);
-      if (!!existing && existing.id !== choreId) {
+      if (existing && existing.id !== choreId) {
         throw new ErrorResponse(
           StatusCodes.UNPROCESSABLE_ENTITY,
           `Chore already exists with name: ${req.body.name}`

--- a/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
+++ b/functions/studio-api/src/routes/admin/chores/ChoresEndpoint.ts
@@ -43,11 +43,15 @@ export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
       throw new ErrorResponse(StatusCodes.BAD_REQUEST, paging.errorMessage);
     }
 
-    const id = parseInt(`${req.params.id}`, 10);
-    if (isNaN(id)) {
-      throw new ErrorResponse(StatusCodes.BAD_REQUEST, 'Invalid id');
+    const chart = await ChoreChart.findByPk(req.params.id);
+    if (!chart) {
+      throw new ErrorResponse(
+        StatusCodes.NOT_FOUND,
+        `Unable to find chart with id: ${req.params.id}`
+      );
     }
-    return await this.choreService.getChores(id, paging);
+
+    return await this.choreService.getChores(chart.id, paging);
   }
 
   /*
@@ -102,7 +106,7 @@ export class ChoresEndpoint extends AdminEndpoint implements RouterClass {
         'Missing endpoint param: id'
       );
     }
-    const choreId: number = parseInt(`${req.params.choreId}`, 10);
+    const choreId: string = req.params.choreId;
     this.logger.info('patching chore with id' + choreId);
     const chore: Chore | null = await Chore.findByPk(choreId);
 

--- a/functions/studio-api/src/routes/index.ts
+++ b/functions/studio-api/src/routes/index.ts
@@ -15,6 +15,7 @@ import ChoreChartsEndpoint from './admin/chores/ChoreChartsEndpoint';
 import UsersEndpoint from './UsersEndpoint';
 import ChoresEndpoint from './admin/chores/ChoresEndpoint';
 import ChoreChartEventsEndpoint from './admin/chores/ChoreChartEventsEndpoint';
+import UserChoresEndpoint from './UserChoresEndpoint';
 
 @singleton()
 @injectable()
@@ -55,6 +56,7 @@ export class ApiRoutes {
       ['/test', [auth()], TestEndpoint],
       ['/me', [auth()], UserProfileEndpoint],
       ['/badges', [auth()], BadgeEndpoint],
+      ['/chores', [auth()], UserChoresEndpoint],
       ['/sessions', [auth()], UserSessionEndpoint],
       ['/users', [auth()], UsersEndpoint],
 

--- a/functions/studio-api/src/routes/index.ts
+++ b/functions/studio-api/src/routes/index.ts
@@ -14,6 +14,7 @@ import AdminBadgesEndpoint from './admin/AdminBadgesEndpoint';
 import ChoreChartsEndpoint from './admin/chores/ChoreChartsEndpoint';
 import UsersEndpoint from './UsersEndpoint';
 import ChoresEndpoint from './admin/chores/ChoresEndpoint';
+import ChoreChartEventsEndpoint from './admin/chores/ChoreChartEventsEndpoint';
 
 @singleton()
 @injectable()
@@ -43,6 +44,7 @@ export class ApiRoutes {
     return [
       // admin endpoints
       ['/admin/badges', [admin()], AdminBadgesEndpoint],
+      ['/admin/chore-charts', [admin()], ChoreChartEventsEndpoint],
       ['/admin/chore-charts', [admin()], ChoresEndpoint],
       ['/admin/chore-charts', [admin()], ChoreChartsEndpoint],
 

--- a/functions/studio-api/src/routes/index.ts
+++ b/functions/studio-api/src/routes/index.ts
@@ -13,6 +13,7 @@ import { BadgeNames } from '../data/models/Badge';
 import AdminBadgesEndpoint from './admin/AdminBadgesEndpoint';
 import ChoreChartsEndpoint from './admin/chores/ChoreChartsEndpoint';
 import UsersEndpoint from './UsersEndpoint';
+import ChoresEndpoint from './admin/chores/ChoresEndpoint';
 
 @singleton()
 @injectable()
@@ -42,6 +43,7 @@ export class ApiRoutes {
     return [
       // admin endpoints
       ['/admin/badges', [admin()], AdminBadgesEndpoint],
+      ['/admin/chore-charts', [admin()], ChoresEndpoint],
       ['/admin/chore-charts', [admin()], ChoreChartsEndpoint],
 
       // using badge middleware

--- a/functions/studio-api/src/routes/index.ts
+++ b/functions/studio-api/src/routes/index.ts
@@ -11,6 +11,8 @@ import UserSessionEndpoint from './UserSessionEndpoint';
 import BadgeEndpoint from './BadgeEndpoint';
 import { BadgeNames } from '../data/models/Badge';
 import AdminBadgesEndpoint from './admin/AdminBadgesEndpoint';
+import ChoreChartsEndpoint from './admin/chores/ChoreChartsEndpoint';
+import UsersEndpoint from './UsersEndpoint';
 
 @singleton()
 @injectable()
@@ -40,6 +42,7 @@ export class ApiRoutes {
     return [
       // admin endpoints
       ['/admin/badges', [admin()], AdminBadgesEndpoint],
+      ['/admin/chore-charts', [admin()], ChoreChartsEndpoint],
 
       // using badge middleware
       // ['/some-endpoint', [badges(BadgeNames.Etc1, BadgeNames.Etc2)], SomeEndpoint],
@@ -49,6 +52,7 @@ export class ApiRoutes {
       ['/me', [auth()], UserProfileEndpoint],
       ['/badges', [auth()], BadgeEndpoint],
       ['/sessions', [auth()], UserSessionEndpoint],
+      ['/users', [auth()], UsersEndpoint],
 
       // optional auth endpoints
       ['/version', [auth(false)], VersionEndpoint],

--- a/functions/studio-api/src/services/Auth.ts
+++ b/functions/studio-api/src/services/Auth.ts
@@ -77,7 +77,7 @@ export class AuthService {
           this.logger.info(`Authenticating user with id ${session?.userId}`);
           req.session = session;
           req.user = await this.userService.getById(session.userId);
-          this.logger.info('added user to request: ' + req.user);
+          // this.logger.info('added user to request: ', req.user?.toJSON);
         }
       }
 

--- a/functions/studio-api/src/services/Auth.ts
+++ b/functions/studio-api/src/services/Auth.ts
@@ -29,7 +29,7 @@ export interface SessionData {
 interface ClaimData {
   sub?: string;
   secret: string;
-  userId: number;
+  userId: string;
 }
 
 @injectable()

--- a/functions/studio-api/src/services/BadgeService.ts
+++ b/functions/studio-api/src/services/BadgeService.ts
@@ -3,6 +3,12 @@ import { StatusCodes } from 'http-status-codes';
 import { inject, singleton } from 'tsyringe';
 import Badge, { BadgeNames } from '../data/models/Badge';
 import User from '../data/models/User';
+import {
+  asOffset,
+  asPagedResponse,
+  Paged,
+  PagingOptions
+} from '../utilities/Pagination';
 import { AuthRequest, AuthService } from './Auth';
 import LoggerFactory, { Logger } from './Logger';
 
@@ -62,7 +68,14 @@ export class BadgeService {
     return badge || undefined;
   }
 
-  public async getBadges(): Promise<{ rows: Badge[]; count: number }> {
-    return await Badge.findAndCountAll();
+  public async getBadges(pagination?: PagingOptions): Promise<Paged<Badge>> {
+    const paging = asOffset(pagination);
+    return asPagedResponse<Badge>(
+      await Badge.findAndCountAll({
+        limit: paging.limit,
+        offset: paging.offset
+      }),
+      paging
+    );
   }
 }

--- a/functions/studio-api/src/services/BadgeService.ts
+++ b/functions/studio-api/src/services/BadgeService.ts
@@ -55,7 +55,7 @@ export class BadgeService {
     };
   }
 
-  public async getUserBadges(userId: number): Promise<Badge[]> {
+  public async getUserBadges(userId: string): Promise<Badge[]> {
     const user = await User.findByPk(userId);
     if (!user) {
       throw new Error('Unable to resolve user from user id: ' + userId);

--- a/functions/studio-api/src/services/ChoreService.ts
+++ b/functions/studio-api/src/services/ChoreService.ts
@@ -1,9 +1,13 @@
 import moment from 'moment';
-import { Op } from 'sequelize';
+import { Op, Transaction, WhereOptions } from 'sequelize';
 import { inject, singleton } from 'tsyringe';
 import Chore, { ChoreOutput } from '../data/models/Chore';
 import ChoreChart, { ChoreChartOutput } from '../data/models/ChoreChart';
-import ChoreChartEvent from '../data/models/ChoreChartEvent';
+import ChoreChartEvent, {
+  ChoreChartEventInput,
+  ChoreChartEventOutput,
+  ChoreEventStatus
+} from '../data/models/ChoreChartEvent';
 import {
   Paged,
   PagingOptions,
@@ -48,10 +52,33 @@ export class ChoreService {
     paging?: PagingOptions
   ): Promise<Paged<ChoreOutput>> {
     const offsetOptions = asOffset(paging);
-    this.logger.error('limit: ' + offsetOptions.limit);
-    this.logger.error('offset: ' + offsetOptions.offset);
     const results = await Chore.findAndCountAll({
       where: { choreChartId: chartId },
+      order: [['id', 'ASC']],
+      limit: offsetOptions.limit,
+      offset: offsetOptions.offset
+    });
+
+    return asPagedResponse(results, offsetOptions);
+  }
+
+  public async getChartEventsForOwner(
+    chartId: number,
+    sinceDate: Date | undefined,
+    paging?: PagingOptions
+  ): Promise<Paged<ChoreChartEventOutput>> {
+    const offsetOptions = asOffset(paging);
+
+    const where: WhereOptions<ChoreChartEvent> = {
+      choreChartId: chartId
+    };
+
+    if (sinceDate) {
+      where.created = { [Op.gte]: sinceDate };
+    }
+
+    const results = await ChoreChartEvent.findAndCountAll({
+      where,
       order: [['id', 'ASC']],
       limit: offsetOptions.limit,
       offset: offsetOptions.offset
@@ -68,6 +95,95 @@ export class ChoreService {
 
   public async getChoreByName(name: string): Promise<Chore | undefined> {
     return (await Chore.findOne({ where: { name } })) || undefined;
+  }
+
+  /*
+    Create chore chart events for the week if they haven't been created yet
+  */
+  public async createChoreEventsIfNeeded(chartId: number): Promise<boolean> {
+    let hasCreatedEvents = false;
+    await ChoreChartEvent.sequelize?.transaction(
+      {
+        type: Transaction.TYPES.EXCLUSIVE,
+        isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
+      },
+      async (t: Transaction) => {
+        const chart = await ChoreChart.findByPk(chartId, {
+          include: [Chore],
+          transaction: t
+        });
+
+        if (!chart) {
+          throw new Error(`Unable to find chore-chart with id ${chartId}`);
+        }
+
+        if (!chart.recurring) {
+          return; // no need for recurring event creation
+        }
+        const currentEvents = await ChoreChartEvent.findAll({
+          where: {
+            choreChartId: chartId,
+            created: {
+              [Op.gt]: moment().startOf('week').toDate()
+            }
+          },
+          transaction: t
+        });
+
+        if (
+          // check if events are missing for this week
+          (!currentEvents || currentEvents.length <= 0) &&
+          (chart?.Chores || []).length > 0
+        ) {
+          // create the events for this week
+          for (const chore of chart.Chores) {
+            await this.createChoreChartEvent(chart, chore, t);
+          }
+          hasCreatedEvents = true;
+        }
+      }
+    );
+    return hasCreatedEvents;
+  }
+
+  /*
+    Create chore chart events for a chore under an existing db transaction
+  */
+  private async createChoreChartEvent(
+    chart: ChoreChart,
+    chore: Chore,
+    trx: Transaction
+  ) {
+    const dayMap: { [k: string]: number } = {
+      M: 1,
+      T: 2,
+      W: 3,
+      R: 4,
+      F: 5,
+      S: 6,
+      U: 7
+    };
+    const days = chore.scheduleDays
+      .split(',')
+      .map((d) => dayMap[d.toUpperCase()] || dayMap.S);
+
+    for (const day of days) {
+      const eventDate = moment().startOf('week').day(day).format('YYYY-MM-DD');
+      const dueDate = moment(eventDate + ' ' + chart.dueTime);
+      const eventInput: ChoreChartEventInput = {
+        choreChartId: chart.id,
+        choreId: chore.id,
+        _status: ChoreEventStatus.TODO.toString(),
+        due: dueDate.toDate(),
+        rating: 0
+      };
+      this.logger.info(
+        `Creating chore chart event [${chart.id}:${chore.id}] ${dueDate
+          .toDate()
+          .toISOString()}`
+      );
+      await ChoreChartEvent.create(eventInput, { transaction: trx });
+    }
   }
 
   /*

--- a/functions/studio-api/src/services/ChoreService.ts
+++ b/functions/studio-api/src/services/ChoreService.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Op } from 'sequelize';
 import { inject, singleton } from 'tsyringe';
-import Chore from '../data/models/Chore';
+import Chore, { ChoreOutput } from '../data/models/Chore';
 import ChoreChart, { ChoreChartOutput } from '../data/models/ChoreChart';
 import ChoreChartEvent from '../data/models/ChoreChartEvent';
 import {
@@ -42,10 +42,31 @@ export class ChoreService {
     return asPagedResponse(results, offsetOptions);
   }
 
+  public async getChores(
+    chartId: number,
+    paging?: PagingOptions
+  ): Promise<Paged<ChoreOutput>> {
+    const offsetOptions = asOffset(paging);
+    this.logger.error('limit: ' + offsetOptions.limit);
+    this.logger.error('offset: ' + offsetOptions.offset);
+    const results = await Chore.findAndCountAll({
+      where: { choreChartId: chartId },
+      order: [['id', 'ASC']],
+      limit: offsetOptions.limit,
+      offset: offsetOptions.offset
+    });
+
+    return asPagedResponse(results, offsetOptions);
+  }
+
   public async getChoreChartByName(
     name: string
   ): Promise<ChoreChart | undefined> {
     return (await ChoreChart.findOne({ where: { name } })) || undefined;
+  }
+
+  public async getChoreByName(name: string): Promise<Chore | undefined> {
+    return (await Chore.findOne({ where: { name } })) || undefined;
   }
 
   /*

--- a/functions/studio-api/src/services/ChoreService.ts
+++ b/functions/studio-api/src/services/ChoreService.ts
@@ -1,0 +1,98 @@
+import moment from 'moment';
+import { Op } from 'sequelize';
+import { inject, singleton } from 'tsyringe';
+import Chore from '../data/models/Chore';
+import ChoreChart, { ChoreChartOutput } from '../data/models/ChoreChart';
+import ChoreChartEvent from '../data/models/ChoreChartEvent';
+import {
+  Paged,
+  PagingOptions,
+  asOffset,
+  asPagedResponse
+} from '../utilities/Pagination';
+import LoggerFactory, { Logger } from './Logger';
+
+export interface ChoreChartData {
+  chart?: ChoreChart;
+  chores?: Array<Chore>;
+  events?: Array<ChoreChartEvent>;
+}
+
+/*
+  ChoreService
+  Provides functionality and operations around Chores, Chore Charts, and Chore Events.
+*/
+@singleton()
+export class ChoreService {
+  private logger: Logger;
+
+  constructor(@inject(LoggerFactory) loggerFactory: LoggerFactory) {
+    this.logger = loggerFactory.getLogger(`app:services:${ChoreService.name}`);
+  }
+
+  public async getCharts(
+    paging?: PagingOptions
+  ): Promise<Paged<ChoreChartOutput>> {
+    const offsetOptions = asOffset(paging);
+    const results = await ChoreChart.findAndCountAll({
+      limit: offsetOptions.limit,
+      offset: offsetOptions.offset
+    });
+
+    return asPagedResponse(results, offsetOptions);
+  }
+
+  public async getChoreChartByName(
+    name: string
+  ): Promise<ChoreChart | undefined> {
+    return (await ChoreChart.findOne({ where: { name } })) || undefined;
+  }
+
+  /*
+    Fetches chart data for a given assignee user id
+  */
+  public async getCurrentChoresForUser(
+    assigneeUserId: number
+  ): Promise<ChoreChartData[]> {
+    const startOfWeek = moment().startOf('week').toDate();
+    this.logger.info(
+      `Fetching chart data for user ${assigneeUserId} since ${startOfWeek.toISOString()}`
+    );
+    const results: Array<ChoreChartData> = [];
+    if (!assigneeUserId) {
+      throw new Error('Missing param user id! ' + assigneeUserId);
+    }
+
+    const charts: ChoreChart[] = await ChoreChart.findAll({
+      where: {
+        assignee: assigneeUserId
+      },
+      include: [Chore]
+    });
+
+    const thisWeeksEvents = await ChoreChartEvent.findAll({
+      where: {
+        choreChartId: [...charts.map((c) => c.id)],
+        choreId: [
+          ...charts
+            .map((chart) => (chart.Chores || []).map((chore) => chore.id))
+            .reduce((acc, idArr) => [...acc, ...idArr], [])
+        ],
+        created: {
+          [Op.gt]: startOfWeek
+        }
+      }
+    });
+
+    for (const chart of charts) {
+      const data: ChoreChartData = {
+        chart,
+        chores: chart.Chores,
+        events: thisWeeksEvents.filter((ev) => ev.choreChartId === chart.id)
+      };
+      results.push(data);
+    }
+
+    return results;
+  }
+}

--- a/functions/studio-api/src/services/ChoreService.ts
+++ b/functions/studio-api/src/services/ChoreService.ts
@@ -35,6 +35,7 @@ export class ChoreService {
   ): Promise<Paged<ChoreChartOutput>> {
     const offsetOptions = asOffset(paging);
     const results = await ChoreChart.findAndCountAll({
+      include: [Chore],
       limit: offsetOptions.limit,
       offset: offsetOptions.offset
     });

--- a/functions/studio-api/src/services/ChoreService.ts
+++ b/functions/studio-api/src/services/ChoreService.ts
@@ -48,7 +48,7 @@ export class ChoreService {
   }
 
   public async getChores(
-    chartId: number,
+    chartId: string,
     paging?: PagingOptions
   ): Promise<Paged<ChoreOutput>> {
     const offsetOptions = asOffset(paging);
@@ -63,7 +63,7 @@ export class ChoreService {
   }
 
   public async getChartEventsForOwner(
-    chartId: number,
+    chartId: string,
     sinceDate: Date | undefined,
     paging?: PagingOptions
   ): Promise<Paged<ChoreChartEventOutput>> {
@@ -100,7 +100,7 @@ export class ChoreService {
   /*
     Create chore chart events for the week if they haven't been created yet
   */
-  public async createChoreEventsIfNeeded(chartId: number): Promise<boolean> {
+  public async createChoreEventsIfNeeded(chartId: string): Promise<boolean> {
     let hasCreatedEvents = false;
     await ChoreChartEvent.sequelize?.transaction(
       {
@@ -190,7 +190,7 @@ export class ChoreService {
     Fetches chart data for a given assignee user id
   */
   public async getCurrentChoresForUser(
-    assigneeUserId: number
+    assigneeUserId: string
   ): Promise<ChoreChartData[]> {
     const startOfWeek = moment().startOf('week').toDate();
     this.logger.info(

--- a/functions/studio-api/src/services/Google.ts
+++ b/functions/studio-api/src/services/Google.ts
@@ -91,7 +91,13 @@ export class GoogleService {
       where: {
         sourceId: googleUser.googleId
       },
-      include: [{ model: Badge, where: { type: BadgeTypes.Administrative } }]
+      include: [
+        {
+          model: Badge,
+          where: { type: BadgeTypes.Administrative },
+          required: false
+        }
+      ]
     });
 
     if (!user) {

--- a/functions/studio-api/src/services/Logger.ts
+++ b/functions/studio-api/src/services/Logger.ts
@@ -79,7 +79,7 @@ class WrappedLogger implements Logger {
 
   public info(...args: unknown[]) {
     // log to console
-    this.debug(`[${this.getActiveRefId()}]`, ...args);
+    this.debug(`info [${this.getActiveRefId()}]`, ...args);
     // this.debug(`[${this.getSmartRef()}]`, ...args);
 
     // and also send to third party monitoring service
@@ -97,7 +97,7 @@ class WrappedLogger implements Logger {
     }
 
     // log to console
-    this.debug(`[${this.getActiveRefId()}]`, ...args);
+    this.debug(`silly [${this.getActiveRefId()}]`, ...args);
     // this.debug(`[${this.getSmartRef()}]`, ...args);
 
     // and also send to third party monitoring service
@@ -111,7 +111,7 @@ class WrappedLogger implements Logger {
 
   public error(...args: unknown[]) {
     // log to console
-    this.debug(`[${this.getActiveRefId()}]`, ...args);
+    this.debug(`error [${this.getActiveRefId()}]`, ...args);
     // this.debug(`[${this.getSmartRef()}]`, ...args);
 
     // and also send to third party monitoring service

--- a/functions/studio-api/src/services/UserService.ts
+++ b/functions/studio-api/src/services/UserService.ts
@@ -52,7 +52,7 @@ export class UserService {
     return user || undefined;
   }
 
-  public async getById(userId: number): Promise<User | undefined> {
+  public async getById(userId: string): Promise<User | undefined> {
     const user = await User.findOne({
       where: { id: userId },
       include: [AccessBadges]
@@ -61,7 +61,7 @@ export class UserService {
     return user || undefined;
   }
 
-  public async getUserProfile(userId: number): Promise<User | undefined> {
+  public async getUserProfile(userId: string): Promise<User | undefined> {
     const user = await User.findOne({
       where: { id: userId },
       include: [Badge]

--- a/functions/studio-api/src/services/UserService.ts
+++ b/functions/studio-api/src/services/UserService.ts
@@ -1,7 +1,13 @@
 import { Includeable } from 'sequelize/types';
 import { inject, singleton } from 'tsyringe';
 import Badge, { BadgeTypes } from '../data/models/Badge';
-import User from '../data/models/User';
+import User, { UserOutput } from '../data/models/User';
+import {
+  asOffset,
+  asPagedResponse,
+  Paged,
+  PagingOptions
+} from '../utilities/Pagination';
 import LoggerFactory, { Logger } from './Logger';
 
 export const AccessBadges: Includeable = {
@@ -22,6 +28,19 @@ export class UserService {
 
   constructor(@inject(LoggerFactory) loggerFactory: LoggerFactory) {
     this.logger = loggerFactory.getLogger(`app:services:${UserService.name}`);
+  }
+
+  public async getUsers(paging?: PagingOptions): Promise<Paged<UserOutput>> {
+    this.logger.info('Fetching users...');
+    const offsetPaging = asOffset(paging);
+
+    return asPagedResponse(
+      await User.findAndCountAll({
+        limit: offsetPaging.limit,
+        offset: offsetPaging.offset
+      }),
+      offsetPaging
+    );
   }
 
   public async getBySourceId(userSourceId: string): Promise<User | undefined> {

--- a/functions/studio-api/src/utilities/EndpointWrapper.ts
+++ b/functions/studio-api/src/utilities/EndpointWrapper.ts
@@ -49,6 +49,7 @@ export const endpointWrapper: CustomWrapper = (
       }
     } catch (error) {
       logger.error(`Error in route ${endpointName} ${handlerName}`);
+      logger.error(error);
       next(error);
     }
   };

--- a/functions/studio-api/src/utilities/EndpointWrapper.ts
+++ b/functions/studio-api/src/utilities/EndpointWrapper.ts
@@ -6,6 +6,7 @@ import {
   Injectables
 } from 'route-harness';
 import LoggerFactory, { Logger } from '../services/Logger';
+import { isDev } from './isDev';
 
 const mapped: Set<string> = new Set();
 
@@ -36,17 +37,29 @@ export const endpointWrapper: CustomWrapper = (
           `, Body: ${JSON.stringify(request.body)} }`
       );
       const result = await handler(request, response);
-      if (result) {
-        if (result.status >= 400 || result.statusCode >= 400) {
-          logger.error(result);
-        }
-        logger.info(
-          `[ ${endpointName} ] ${handlerName}.Response: ${JSON.stringify(
-            result
-          )}`
-        );
-        response.send(result);
+      if (!result) {
+        return;
       }
+
+      if (result.status >= 400 || result.statusCode >= 400) {
+        logger.error(result);
+      } else {
+        const responseLogMessage = `[ ${endpointName} ] ${handlerName}.Response: ${
+          result.status || result.statusCode || 200
+        }`;
+        logger.info(
+          responseLogMessage +
+            // include success response data in development logs only
+            (isDev
+              ? `\n${JSON.stringify(
+                  result
+                  // undefined,
+                  // 2
+                )}`
+              : '')
+        );
+      }
+      response.send(result);
     } catch (error) {
       logger.error(`Error in route ${endpointName} ${handlerName}`);
       logger.error(error);

--- a/functions/studio-api/src/utilities/Pagination.ts
+++ b/functions/studio-api/src/utilities/Pagination.ts
@@ -59,7 +59,7 @@ export function pagingFromRequest(req: AuthRequest): ParsedPaging {
     paging.pageSize = parseInt(`${sizeParam}`, 10);
     if (isNaN(paging.pageSize)) {
       paging.errorMessage =
-        (!!paging.errorMessage ? '; ' : '') +
+        (paging.errorMessage ? '; ' : '') +
         `Invalid input for number param: pageSize. Received: ${sizeParam}`;
     }
   }
@@ -81,7 +81,7 @@ export function pagingFromRequest(req: AuthRequest): ParsedPaging {
     paging.pageSize = parseInt(`${pageSize}`, 10);
     if (isNaN(paging.pageSize)) {
       paging.errorMessage =
-        (!!paging.errorMessage ? '; ' : '') +
+        (paging.errorMessage ? '; ' : '') +
         `Invalid input for number param: pageSize. Received: ${pageSize}`;
     }
   }
@@ -90,8 +90,8 @@ export function pagingFromRequest(req: AuthRequest): ParsedPaging {
 }
 
 export function asOffset(paging?: PagingOptions): OffsetPaging {
-  const BASE_TEN: number = 10;
-  const MAX_PAGE_SIZE: number = 500;
+  const BASE_TEN = 10;
+  const MAX_PAGE_SIZE = 500;
 
   const page: number = Math.max(
     parseInt(`${paging?.page || DefaultPaging.page}`, BASE_TEN),
@@ -116,8 +116,10 @@ export function asOffset(paging?: PagingOptions): OffsetPaging {
 
 export function attemptToJSON<T, V = T | Partial<T>>(obj: T): T | V {
   try {
-    if (typeof (obj as any)?.toJSON === 'function') {
-      return (obj as any).toJSON() as V;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const o = obj as any;
+    if (typeof o?.toJSON === 'function') {
+      return o.toJSON() as V;
     }
     return obj;
   } catch (err) {

--- a/functions/studio-api/src/utilities/Pagination.ts
+++ b/functions/studio-api/src/utilities/Pagination.ts
@@ -103,7 +103,7 @@ export function asOffset(paging?: PagingOptions): OffsetPaging {
   );
 
   const res: OffsetPaging = {
-    offset: page == 1 ? 0 : page * pageSize,
+    offset: page <= 1 ? 0 : (page - 1) * pageSize,
     limit: pageSize,
     original: {
       page,

--- a/functions/studio-api/src/utilities/Pagination.ts
+++ b/functions/studio-api/src/utilities/Pagination.ts
@@ -1,0 +1,139 @@
+import { AuthRequest } from '../services/Auth';
+
+/*
+  External facing types
+*/
+
+export interface Paged<T> {
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  results: Array<T>;
+}
+
+export interface PagingOptions {
+  page?: number | string;
+  pageSize?: number | string;
+}
+
+/*
+  Pagination Helper Types
+*/
+
+export interface ParsedPaging extends PagingOptions {
+  errorMessage?: string;
+}
+
+export const DefaultPaging = {
+  page: 1,
+  pageSize: 100
+};
+
+export interface OffsetPaging {
+  offset: number;
+  limit: number;
+
+  original: {
+    page: number;
+    pageSize: number;
+  };
+}
+
+/*
+  Pagination Helper Functions
+*/
+
+export function pagingFromRequest(req: AuthRequest): ParsedPaging {
+  const paging: ParsedPaging = {};
+
+  // check the query parameters
+  const { page: pageParam, pageSize: sizeParam } = req.query || {};
+  if (pageParam) {
+    paging.page = parseInt(`${pageParam}`, 10);
+    if (isNaN(paging.page)) {
+      paging.errorMessage = `Invalid input for number param: page. Received: ${pageParam}`;
+    }
+  }
+
+  if (sizeParam) {
+    paging.pageSize = parseInt(`${sizeParam}`, 10);
+    if (isNaN(paging.pageSize)) {
+      paging.errorMessage =
+        (!!paging.errorMessage ? '; ' : '') +
+        `Invalid input for number param: pageSize. Received: ${sizeParam}`;
+    }
+  }
+
+  if (pageParam || sizeParam || paging.errorMessage) {
+    return paging;
+  }
+
+  // check the body
+  const { page, pageSize } = req.body || {};
+  if (page) {
+    paging.page = parseInt(`${page}`, 10);
+    if (isNaN(paging.page)) {
+      paging.errorMessage = `Invalid input for number param: page. Received: ${page}`;
+    }
+  }
+
+  if (pageSize) {
+    paging.pageSize = parseInt(`${pageSize}`, 10);
+    if (isNaN(paging.pageSize)) {
+      paging.errorMessage =
+        (!!paging.errorMessage ? '; ' : '') +
+        `Invalid input for number param: pageSize. Received: ${pageSize}`;
+    }
+  }
+
+  return paging;
+}
+
+export function asOffset(paging?: PagingOptions): OffsetPaging {
+  const BASE_TEN: number = 10;
+  const MAX_PAGE_SIZE: number = 500;
+
+  const page: number = Math.max(
+    parseInt(`${paging?.page || DefaultPaging.page}`, BASE_TEN),
+    DefaultPaging.page
+  );
+  const pageSize: number = Math.min(
+    parseInt(`${paging?.pageSize || DefaultPaging.pageSize}`, BASE_TEN),
+    MAX_PAGE_SIZE
+  );
+
+  const res: OffsetPaging = {
+    offset: page == 1 ? 0 : page * pageSize,
+    limit: pageSize,
+    original: {
+      page,
+      pageSize
+    }
+  };
+
+  return res;
+}
+
+export function attemptToJSON<T, V = T | Partial<T>>(obj: T): T | V {
+  try {
+    if (typeof (obj as any)?.toJSON === 'function') {
+      return (obj as any).toJSON() as V;
+    }
+    return obj;
+  } catch (err) {
+    return obj;
+  }
+}
+
+export function asPagedResponse<T, V = T>(
+  dbResponse: { rows: Array<T>; count: number },
+  offsets: OffsetPaging,
+  mapResults: (result: T) => T | V = attemptToJSON
+): Paged<T | V> {
+  return {
+    page: offsets.original.page,
+    pageSize: offsets.original.pageSize,
+    totalCount: dbResponse.count,
+    results: (dbResponse.rows || []).map(mapResults)
+  };
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,7 @@
   [dev]
    command = "yarn devrun" # Command to start your dev server
    port = 7447 # Port that the dev server will be listening on
+   targetPort = 3000
    publish = "dist" # Folder with the static content for _redirect file
    functionsPort = 8888
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olson-studio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "dev": "npm run build-functions && DEBUG=app* netlify dev",
     "run-ui-for-prod-locally": "yarn build && yarn serve",

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 export class Footer extends React.Component {
   public render() {
+    const copyrightYear = new Date().getFullYear();
     return (
       <div className="nav">
-        © 2022{' '}
+        © {copyrightYear + ' '}
         <a href="https://olson.studio" rel="noopener" target="_blank">
           Olson Studio
         </a>

--- a/src/types/StudioApiTypes.ts
+++ b/src/types/StudioApiTypes.ts
@@ -4,7 +4,7 @@ export enum StudioBadgeTypes {
 }
 
 export interface StudioApiBadge {
-  id: number;
+  id: string;
   friendlyName: string;
   name: string;
   description: string;
@@ -15,11 +15,11 @@ export interface StudioApiBadge {
   rarity: number;
   obtained?: Date;
   unread?: boolean;
-  userId?: number;
+  userId?: string;
 }
 
 export interface StudioApiUser {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;


### PR DESCRIPTION
- Adds endpoints for managing chores and chore charts
- Adjust ID types to mirror prod
- Adds settings so we can update global cli version `netlify-cli/12.10.0`
- Bumps package.json `version` for new endpoint functionality that was added
- Also updates copyright year on ui footer